### PR TITLE
Remove using the minified stylesheets

### DIFF
--- a/templates/mtp_base.html
+++ b/templates/mtp_base.html
@@ -21,13 +21,8 @@
 
 
 {% block stylesheets %}
-  {% if debug %}
-    <link rel="stylesheet" href="{% static "stylesheets/app.css" %}" media="screen, handheld, projection, tv">
-    <link rel="stylesheet" href="{% static "stylesheets/app-print.css" %}" media="print">
-  {% else %}
-    <link rel="stylesheet" href="{% static "stylesheets/app.min.css" %}" media="screen, handheld, projection, tv">
-    <link rel="stylesheet" href="{% static "stylesheets/app-print.min.css" %}" media="print">
-  {% endif %}
+  <link rel="stylesheet" href="{% static "stylesheets/app.css" %}" media="screen, handheld, projection, tv">
+  <link rel="stylesheet" href="{% static "stylesheets/app-print.css" %}" media="print">
 {% endblock %}
 
 


### PR DESCRIPTION
because:
1. The minified stylesheets (generated using clean-css) break the style on IE8
2. They only give a 2% gain in file size
Until we investigate a new minified that works on IE8 or we (wait for a) fix in clean-css,
we choose just to remove it. [Updates: #110145316]