### PR TITLE
Prevent `nc` from outputting any text in verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ TASK_OUTPUT_REDIRECTION := /dev/null
 endif
 
 # functions
-is_port_open = $(shell nc -z localhost $(1) >$(TASK_OUTPUT_REDIRECTION) 2>&1 && echo true)
+is_port_open = $(shell nc -z localhost $(1) >/dev/null 2>&1 && echo true)
 
 # paths of folders, tools and assets
 NODE_MODULES := node_modules


### PR DESCRIPTION
as this messes up the check for an open port