### PR TITLE
Generic form error styling

### DIFF
--- a/templates/forms/generic.html
+++ b/templates/forms/generic.html
@@ -19,7 +19,7 @@
                     {% endif %}
                     {% for error in errors %}
                       {% if not forloop.first  %}
-                        {% trans 'and' %}
+                        <br/>
                       {% endif %}
                       {{ error }}
                     {% endfor %}
@@ -27,6 +27,7 @@
                       </a>
                     {% endif %}
                 {% endwith %}
+                <br/>
               {% endfor %}
             </ol>
           </div>


### PR DESCRIPTION
Make the errors at the top of the form more readable.