### PR TITLE
Silence python warnings if verbosity is set to zero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ verbosity ?= 1
 ifeq ($(shell [ $(verbosity) -gt 1 ] && echo true),true)
 TASK_OUTPUT_REDIRECTION := &1
 PYTHON_WARNINGS := "-W default"
+else ifeq ($(shell [ $(verbosity) -eq 0 ] && echo true),true)
+TASK_OUTPUT_REDIRECTION := /dev/null
+PYTHON_WARNINGS := "-W ignore"
 else
 TASK_OUTPUT_REDIRECTION := /dev/null
 PYTHON_WARNINGS := "-W once"


### PR DESCRIPTION
i.e. `make … verbosity=0`