### PR TITLE
Ensure selenium standalone web drivers are installed when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ uwsgi: venv/bin/uwsgi static_assets
 
 # run python tests
 .PHONY: test
-test: .api_running build
+test: $(SELENIUM) .api_running build
 ifdef RUN_FUNCTIONAL_TESTS
 	@echo Running all tests
 else

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-to-prisoners-common",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Assets common to all money-to-prisoners applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
c.f. [send-money#46](https://github.com/ministryofjustice/money-to-prisoners-send-money/pull/46)