### PR TITLE
Set initial aria value to not-expanded

### DIFF
--- a/assets/javascripts/modules/help-popup.js
+++ b/assets/javascripts/modules/help-popup.js
@@ -9,7 +9,9 @@ exports.HelpPopup = {
     var $helpTitle = $('.help-box h3');
     if ($helpBoxes.length) {
       $helpBoxes.addClass('help-box-popup help-box-hidden');
-      $helpTitle.on('click', this.toggle);
+      $helpTitle
+        .attr('aria-expanded', 'false')
+        .on('click', this.toggle);
     }
   },
 


### PR DESCRIPTION
Because we need the attribute to be correct in case JS is absent,
we will set it to open in the markup, and initally close it with JS,
just like we set its initial visibility to hidden