### PR TITLE
Handle reveal/hide controls if target is inside an h3

### DIFF
--- a/assets/javascripts/modules/help-popup.js
+++ b/assets/javascripts/modules/help-popup.js
@@ -6,17 +6,17 @@ exports.HelpPopup = {
 
   init: function () {
     var $helpBoxes = $('.help-box');
-    var $helpTitle = $('.help-box h3');
+    var $helpTitles = $('.help-box h3');
     if ($helpBoxes.length) {
       $helpBoxes.addClass('help-box-popup help-box-hidden');
-      $helpTitle
+      $helpTitles
         .attr('aria-expanded', 'false')
         .on('click', this.toggle);
     }
   },
 
   toggle: function(event) {
-    var $helpTitle = $(event.target);
+    var $helpTitle = $(event.target).parent('h3');
     var $helpBox = $(event.target).closest('div.help-box');
     var $contents = $helpBox.find('.help-box-contents');
     event.preventDefault();


### PR DESCRIPTION
This is because the markup of the component will contain an a inside an h3
so that we can tab into the control