### PR TITLE
Add error message styling to non-field errors in summary

### DIFF
--- a/assets/scss/elements/_forms.scss
+++ b/assets/scss/elements/_forms.scss
@@ -16,3 +16,12 @@ form a.cancel {
 form.admin-form {
   width: 70%;
 }
+
+.error-summary {
+  .error-summary-list {
+    .non-field-error {
+      color: $error-colour;
+      font-weight: bold;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "money-to-prisoners-common",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "Assets common to all money-to-prisoners applications",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
(which cannot be wrapped in an anchor since there's nowhere to link to)