### PR TITLE
Allow apps to specify where "return home" links to from change password confirmations

### DIFF
--- a/mtp_common/templates/mtp_common/auth/password_change_done.html
+++ b/mtp_common/templates/mtp_common/auth/password_change_done.html
@@ -7,7 +7,7 @@
   <div class="grid-row">
     <div class="column-two-thirds">
       <p>{% trans 'Your password has been changed.' %}</p>
-      <p><a href="/">{% trans 'Return to the home page' %}</a></p>
+      <p><a href="{{ cancel_url }}">{% trans 'Return to the home page' %}</a></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
depends on [moj-auth#25](https://github.com/ministryofjustice/django-moj-auth/pull/25)