### PR TITLE
Remove more full stops at the end of error messages

### DIFF
--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (3, 5, 0)
+VERSION = (3, 6, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/mtp_common/assets/scss/_base.scss
+++ b/mtp_common/assets/scss/_base.scss
@@ -31,3 +31,12 @@
     padding-left: 4.8em;
   }
 }
+
+// Text only for screen readers
+.screenreader-only {
+  height: 1px;
+  width: 1px;
+  position: absolute;
+  overflow: hidden;
+  top: -10px;
+}

--- a/mtp_common/forms/__init__.py
+++ b/mtp_common/forms/__init__.py
@@ -1,12 +1,25 @@
 from django import forms
-from django.core.validators import EmailValidator
+from django.core import validators
 from django.utils.translation import ugettext_lazy as _
 
 
 def replace_default_error_messages():
     """
     Replace Django's generic error messages with MTP-specific versions
-    NB: avoid trailing full stops
+    NB: avoid trailing full stops visually, they are added for screen readers in templates
     """
-    forms.CharField.default_error_messages['required'] = _('This field is required')
-    EmailValidator.message = _('Enter a valid email address')
+    forms.Field.default_error_messages['required'] = _('This field is required')
+    forms.IntegerField.default_error_messages['invalid'] = _('Enter a whole number')
+    forms.FloatField.default_error_messages['invalid'] = _('Enter a number')
+    forms.DecimalField.default_error_messages['invalid'] = _('Enter a number')
+    forms.DateField.default_error_messages['invalid'] = _('Enter a valid date')
+    forms.TimeField.default_error_messages['invalid'] = _('Enter a valid time')
+    forms.DateTimeField.default_error_messages['invalid'] = _('Enter a valid date and time')
+    forms.FileField.default_error_messages.update({
+        'invalid': _('No file was submitted'),
+        'missing': _('No file was submitted'),
+        'empty': _('The submitted file is empty'),
+    })
+    forms.SplitDateTimeField.default_error_messages['invalid_date'] = _('Enter a valid date')
+    forms.SplitDateTimeField.default_error_messages['invalid_time'] = _('Enter a valid time')
+    validators.EmailValidator.message = _('Enter a valid email address')

--- a/mtp_common/templates/mtp_common/forms/error-summary.html
+++ b/mtp_common/templates/mtp_common/forms/error-summary.html
@@ -9,7 +9,7 @@
 {% if form.errors %}
   <div class="error-summary" aria-labelledby="error-summary-heading" tabindex="-1" role="alert">
     <h1 class="error-summary-heading heading-medium" id="error-summary-heading">
-      {% trans 'There was a problem submitting the form' as error_summary_title %}
+      {% trans 'There was a problem' as error_summary_title %}
       {{ form.error_summary_title|default:error_summary_title }}
     </h1>
     <ol class="error-summary-list">
@@ -18,7 +18,7 @@
       {#     but non-field errors are only included in the summary #}
 
       {% for error in errors.non_field %}
-        <li class="non-field-error">{{ error }}</li>
+        <li class="non-field-error">{{ error }}<span class="screenreader-only">.</span></li>
       {% endfor %}
 
       {% for field, field_errors in errors.field_specific.items %}

--- a/mtp_common/templates/mtp_common/forms/field-errors.html
+++ b/mtp_common/templates/mtp_common/forms/field-errors.html
@@ -4,5 +4,5 @@
 {% endcomment %}
 
 {% for error in field.errors %}
-  <span class="error-message">{{ error }}</span>
+  <span class="error-message">{{ error }}<span class="screenreader-only">.</span></span>
 {% endfor %}

--- a/tests/test_error_summary.py
+++ b/tests/test_error_summary.py
@@ -31,7 +31,7 @@ class ErrorSummaryTestCase(SimpleTestCase):
     def test_field_summary_shows(self):
         form = TestForm(data={})
         response = self.load_mocked_template(template, {'form': form})
-        self.assertContains(response, 'There was a problem submitting the form')
+        self.assertContains(response, 'There was a problem')
         response_content = response.content.decode(response.charset)
         self.assertIn('Please correct the following errors', response_content)
         self.assertIn('FIELD A', response_content)
@@ -40,7 +40,7 @@ class ErrorSummaryTestCase(SimpleTestCase):
         form = TestForm(data={'test_field': 'test'})
         form.create_general_error = True
         response = self.load_mocked_template(template, {'form': form})
-        self.assertContains(response, 'There was a problem submitting the form')
+        self.assertContains(response, 'There was a problem')
         response_content = response.content.decode(response.charset)
         self.assertIn('General error', response_content)
         self.assertNotIn('Also, please correct the following errors', response_content)


### PR DESCRIPTION
visually; they're still there for screen readers