### PR TITLE
Remove the outline when the main content of the page is in focus

### DIFF
--- a/mtp_common/assets/scss/_mtp.scss
+++ b/mtp_common/assets/scss/_mtp.scss
@@ -38,3 +38,7 @@
 strong {
   font-weight: bold;
 }
+
+#content {
+  outline: none;
+}


### PR DESCRIPTION
the tabindex attribute set on the main element causes the focus to be visible
on some browsers. This rule (oddly not present in govuk_template) hides it