### PR TITLE
Add URL whitelist to sentry JS error reporting

### DIFF
--- a/mtp_common/templates/mtp_common/sentry-js.html
+++ b/mtp_common/templates/mtp_common/sentry-js.html
@@ -1,4 +1,8 @@
 {% if sentry_dsn %}
   <script src="https://cdn.ravenjs.com/3.8.1/raven.min.js" crossorigin="anonymous"></script>
-  <script>Raven.config('{{ sentry_dsn }}').install()</script>
+  <script>
+    Raven.config('{{ sentry_dsn }}', {
+      whitelistUrls: [/app\.bundle\.js/]
+    }).install()
+  </script>
 {% endif %}


### PR DESCRIPTION
Will now only create sentry errors for exceptions in our
javascript bundle.