### PR TITLE
Remove node dependencies that are not directly used and split into dev and non-dev

### DIFF
--- a/mtp_common/templates/mtp_common/build_tasks/package.json
+++ b/mtp_common/templates/mtp_common/build_tasks/package.json
@@ -14,30 +14,20 @@
     "unsafe-perm": true
   },
   "license": "MIT",
+  "devDependencies": {
+    "browser-sync": "^2.18.2",
+    "eslint": "^3.11.1",
+    "sass-lint": "^1.10.2",
+    "phantomjs-prebuilt": "^2.1.13",
+    "selenium-standalone": "^5.7.2"
+  },
   "dependencies": {
     "breakpoint-sass": "^2.6.1",
-    "browser-sync": "^2.18.2",
-    "chai": "^3.2.0", {# check if needed #}
-    "chai-as-promised": "^5.1.0", {# check if needed #}
-    "checked-polyfill": "ministryofjustice/checked-polyfill#1.0.0", {# check if needed #}
-    "cucumber": "^0.5.3", {# check if needed #}
-    "del": "^2.0.2", {# check if needed #}
-    "eslint": "^3.11.1",
-    "globule": "^0.2.0", {# check if needed #}
+    "checked-polyfill": "ministryofjustice/checked-polyfill#1.0.0",
     "govuk-elements-sass": "~2.2.1",
-    "imports-loader": "^0.6.5", {# check if needed #}
     "jquery": "~1.11",
     "js-cookie": "~2.0.3",
     "node-sass": "^3.4.2",
-    "phantomjs-prebuilt": "^2.1.13",
-    "q": "^1.4.1", {# check if needed #}
-    "request": "^2.63.0", {# check if needed #}
-    "require-dir": "^0.3.0", {# check if needed #}
-    "sanitize-filename": "^1.4.3", {# check if needed #}
-    "sass-lint": "^1.10.2",
-    "selenium-standalone": "^5.7.2",
-    "webdriverio": "^3.2.4", {# check if needed #}
-    "webpack": "^1.13.3",
-    "yargs": "^3.24.0" {# check if needed #}
+    "webpack": "^1.13.3"
   }
 }


### PR DESCRIPTION
… with the aim of logically separating test and build dependencies (however both need to be installed in docker images in order to fully build)