### PR TITLE
Add WorkdayChecker to mtp-common

### DIFF
--- a/mtp_common/dates.py
+++ b/mtp_common/dates.py
@@ -1,0 +1,27 @@
+from datetime import timedelta
+
+from govuk_bank_holidays import bank_holidays
+
+
+class WorkdayChecker:
+
+    def __init__(self):
+        self.holiday_checker = bank_holidays.BankHolidays()
+
+    def is_workday(self, date):
+        return (
+            date.weekday() < 5 and
+            not self.holiday_checker.is_holiday(date, division='england-and-wales')
+        )
+
+    def get_next_workday(self, date):
+        next_day = date + timedelta(days=1)
+        while not self.is_workday(next_day):
+            next_day += timedelta(days=1)
+        return next_day
+
+    def get_previous_workday(self, date):
+        previous_day = date - timedelta(days=1)
+        while not self.is_workday(previous_day):
+            previous_day -= timedelta(days=1)
+        return previous_day

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ install_requires = [
     'slumber>=0.7,<0.8',
     'selenium>=3.0,<3.1',
     'transifex-client>=0.12,<0.13',
+    'govuk-bank-holidays==0.1',
 ]
 extras_require = {
     'monitoring': [

--- a/tests/test_dates.py
+++ b/tests/test_dates.py
@@ -1,0 +1,55 @@
+from unittest import mock
+from datetime import date
+
+from django.test import SimpleTestCase
+
+from mtp_common.dates import WorkdayChecker
+
+TEST_HOLIDAYS = {'england-and-wales': {
+    'division': 'england-and-wales',
+    'events': [
+        {'title': 'Boxing Day', 'date': '2016-12-26', 'notes': '', 'bunting': True},
+        {'title': 'Christmas Day', 'date': '2016-12-27', 'notes': 'Substitute day', 'bunting': True}]
+}}
+
+
+class WorkdayCheckerTestCase(SimpleTestCase):
+
+    def setUp(self):
+        with mock.patch('govuk_bank_holidays.bank_holidays.requests') as mock_requests:
+            mock_requests.get().status_code = 200
+            mock_requests.get().json.return_value = TEST_HOLIDAYS
+            self.checker = WorkdayChecker()
+
+    def test_christmas_is_not_workday(self):
+        self.assertFalse(self.checker.is_workday(date(2016, 12, 27)))
+
+    def test_weekend_is_not_workday(self):
+        self.assertFalse(self.checker.is_workday(date(2016, 12, 17)))
+
+    def test_weekday_is_workday(self):
+        self.assertTrue(self.checker.is_workday(date(2016, 12, 21)))
+
+    def test_next_workday_middle_of_week(self):
+        next_day = self.checker.get_next_workday(date(2016, 12, 21))
+        self.assertEqual(next_day, date(2016, 12, 22))
+
+    def test_next_workday_weekend(self):
+        next_day = self.checker.get_next_workday(date(2016, 12, 16))
+        self.assertEqual(next_day, date(2016, 12, 19))
+
+    def test_next_workday_bank_holidays(self):
+        next_day = self.checker.get_next_workday(date(2016, 12, 23))
+        self.assertEqual(next_day, date(2016, 12, 28))
+
+    def test_previous_workday_middle_of_week(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 22))
+        self.assertEqual(previous_day, date(2016, 12, 21))
+
+    def test_previous_workday_weekend(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 19))
+        self.assertEqual(previous_day, date(2016, 12, 16))
+
+    def test_previous_workday_bank_holidays(self):
+        previous_day = self.checker.get_previous_workday(date(2016, 12, 28))
+        self.assertEqual(previous_day, date(2016, 12, 23))


### PR DESCRIPTION
Originally part of mtp-bank-admin, WorkdayChecker is a utility
for checking the next and previosu workdays for a given date
based on the gov.uk bank holiday web service.