### PR TITLE
Fix user admin tests’ mocked login and get prison count from user data

### DIFF
--- a/mtp_common/user_admin/views.py
+++ b/mtp_common/user_admin/views.py
@@ -179,7 +179,7 @@ class UserCreationView(UserFormView):
         context_data = super().get_context_data(**kwargs)
 
         # TODO: this note only applies to cashbook; we need a way to pass it in from client apps
-        prison_count = api_client.get_connection(self.request).prisons.get().get('count', 0)
+        prison_count = len(self.request.user.user_data.get('prisons', []))
         if prison_count > 0:
             context_data['permissions_note'] = ngettext(
                 'The new user will have access to the same prison as you do.',

--- a/tests/test_user_admin_views.py
+++ b/tests/test_user_admin_views.py
@@ -13,7 +13,7 @@ class UserAdminTestCase(SimpleTestCase):
     def mocked_login(self):
         with mock.patch('django.contrib.auth.login') as mock_login, \
                 mock.patch('mtp_common.auth.backends.api_client') as mock_api_client:
-            mock_login.side_effect = login
+            mock_login.side_effect = lambda request, user, *args: login(request, user)
             mock_api_client.authenticate.return_value = {
                 'pk': 1,
                 'token': 'xxx',
@@ -25,6 +25,7 @@ class UserAdminTestCase(SimpleTestCase):
                     'permissions': [
                         'auth.add_user', 'auth.change_user', 'auth.delete_user',
                     ],
+                    'prisons': [{'nomis_id': 'AAI', 'name': 'Prison 1', 'pre_approval_required': False}],
                 }
             }
             self.assertTrue(self.client.login(username='test-user',


### PR DESCRIPTION
rather than calling an API (whose response is changing)