### PR TITLE
Fix error due to lack of permissions data when editing self

### DIFF
--- a/mtp_common/templates/mtp_common/user_admin/user-description.html
+++ b/mtp_common/templates/mtp_common/user_admin/user-description.html
@@ -5,7 +5,9 @@
   <li>{% blocktrans with first_name=user.first_name %}First name: {{ first_name }}{% endblocktrans %}</li>
   <li>{% blocktrans with last_name=user.last_name %}Last name: {{ last_name }}{% endblocktrans %}</li>
   <li>{% blocktrans with email=user.email %}Email: {{ email }}{% endblocktrans %}</li>
-  <li>{% blocktrans with yes_or_no=user.user_admin|yesno|capfirst %}Can manage other users: {{ yes_or_no }}{% endblocktrans %}</li>
+  {% if 'user_admin' in user %}
+    <li>{% blocktrans with yes_or_no=user.user_admin|yesno|capfirst %}Can manage other users: {{ yes_or_no }}{% endblocktrans %}</li>
+  {% endif %}
   {% if 'is_active' in user %}
     <li>{% blocktrans with yes_or_no=user.is_active|yesno|capfirst %}Can log in: {{ yes_or_no }}{% endblocktrans %}</li>
   {% endif %}

--- a/mtp_common/user_admin/forms.py
+++ b/mtp_common/user_admin/forms.py
@@ -54,9 +54,11 @@ class UserUpdateForm(GARequestErrorReportingMixin, forms.Form):
                 'first_name': self.cleaned_data['first_name'],
                 'last_name': self.cleaned_data['last_name'],
                 'email': self.cleaned_data['email'],
-                'user_admin': self.cleaned_data['user_admin'],
-                'role': self.cleaned_data['role'],
             }
+            if 'user_admin' in self.cleaned_data:
+                data['user_admin'] = self.cleaned_data['user_admin']
+            if 'role' in self.cleaned_data:
+                data['role'] = self.cleaned_data['role']
             try:
                 admin_username = self.request.user.user_data.get('username', 'Unknown')
 


### PR DESCRIPTION
When a user edits themselves the fields for permissions are not
displayed. However, when they attempt to save any changes that they
make to themselves, they receive an error due to the permissions info
being absent from the form.