### PR TITLE
Allow for hiding certain elements when using a print link

### DIFF
--- a/mtp_common/assets-src/javascripts/modules/print.js
+++ b/mtp_common/assets-src/javascripts/modules/print.js
@@ -54,8 +54,15 @@ exports.Print = {
     // trigger a render of this object to check if the cookie is set
     this.$body.trigger('Print.render');
 
+    // hide additional element
+    var $el = $(e.target);
+    var $toHide = $($el.data('do-not-print')).not('.print-hidden');
+    $toHide.addClass('print-hidden');
+
     try {
       window.print();
     } catch (e) {}  // eslint-disable-line
+
+    $toHide.removeClass('print-hidden');
   }
 };


### PR DESCRIPTION
If printing by clicking a specific link, elements specified by the
selector in the links data-do-not-print attribute will be hidden
from that print out only.