### PR TITLE
Allow URLs to be hidden in print version

### DIFF
--- a/mtp_common/assets-src/stylesheets/_print-basic.scss
+++ b/mtp_common/assets-src/stylesheets/_print-basic.scss
@@ -4,3 +4,12 @@
 .print-hidden {
   display: none;
 }
+
+a.mtp-print-url-hidden {
+  text-decoration: none !important;
+
+  &:after {
+    content: '' !important;
+    display: none !important;
+  }
+}


### PR DESCRIPTION
so links do not show up as such when printed when the URL is not useful