### PR TITLE
Change password reset to email a link rather than a new password

### DIFF
--- a/mtp_common/auth/forms.py
+++ b/mtp_common/auth/forms.py
@@ -2,16 +2,19 @@ import json
 import logging
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import authenticate
 from django.utils.translation import gettext_lazy as _
 from form_error_reporting import GARequestErrorReportingMixin
 from requests.exceptions import ConnectionError
-from slumber.exceptions import HttpClientError
+from slumber.exceptions import HttpClientError, HttpNotFoundError
 
 from . import api_client
 from .exceptions import Unauthorized, Forbidden
 
 logger = logging.getLogger('mtp')
+
+RESET_CODE_PARAM = 'reset_code'
 
 
 class AuthenticationForm(GARequestErrorReportingMixin, forms.Form):
@@ -126,7 +129,8 @@ class ResetPasswordForm(GARequestErrorReportingMixin, forms.Form):
     }
     username = forms.CharField(label=_('Username or email address'))
 
-    def __init__(self, request=None, *args, **kwargs):
+    def __init__(self, password_change_url, request=None, *args, **kwargs):
+        self.password_change_url = password_change_url
         self.request = request
         super(ResetPasswordForm, self).__init__(*args, **kwargs)
 
@@ -135,8 +139,68 @@ class ResetPasswordForm(GARequestErrorReportingMixin, forms.Form):
             username = self.cleaned_data.get('username')
             try:
                 api_client.get_unauthenticated_connection().reset_password.post(
-                    {'username': username}
+                    {
+                        'username': username,
+                        'create_password': {
+                            'password_change_url': settings.SITE_URL + str(self.password_change_url),
+                            'reset_code_param': RESET_CODE_PARAM
+                        }
+                    }
                 )
+            except HttpClientError as e:
+                try:
+                    response_body = json.loads(e.content.decode('utf-8'))
+                    for field in response_body['errors']:
+                        for error in response_body['errors'][field]:
+                            self.add_error(field, error)
+                except Exception:
+                    logger.exception('Could not display password change error')
+                    raise forms.ValidationError(self.error_messages['generic'])
+
+
+class PasswordChangeWithCodeForm(GARequestErrorReportingMixin, forms.Form):
+    """
+    A form that lets a user change their password if they have a reset code.
+    """
+    error_messages = {
+        'code_expired': _('This link for resetting your password has expired'),
+        'password_mismatch': _('You’ve entered different passwords'),
+        'generic': _('This service is currently unavailable'),
+    }
+    reset_code = forms.CharField(label=_('Reset code'),
+                                 widget=forms.HiddenInput)
+    new_password = forms.CharField(label=_('New password'),
+                                   widget=forms.PasswordInput)
+    new_password_confirmation = forms.CharField(label=_('New password confirmation'),
+                                                widget=forms.PasswordInput)
+
+    def __init__(self, reset_code=None, request=None, *args, **kwargs):
+        self.request = request
+        super().__init__(*args, **kwargs)
+        if reset_code:
+            self.fields['reset_code'].initial = reset_code
+
+    def clean_new_password_confirmation(self):
+        password1 = self.cleaned_data.get('new_password')
+        password2 = self.cleaned_data.get('new_password_confirmation')
+        if password1 and password2:
+            if password1 != password2:
+                raise forms.ValidationError(
+                    self.error_messages['password_mismatch'],
+                    code='password_mismatch',
+                )
+        return password2
+
+    def clean(self):
+        if self.is_valid():
+            code = self.cleaned_data.get('reset_code')
+            new_password = self.cleaned_data.get('new_password')
+            try:
+                api_client.get_connection(self.request).change_password(code).post(
+                    {'new_password': new_password}
+                )
+            except HttpNotFoundError:
+                raise forms.ValidationError(self.error_messages['code_expired'])
             except HttpClientError as e:
                 try:
                     response_body = json.loads(e.content.decode('utf-8'))

--- a/mtp_common/locale/cy/LC_MESSAGES/django.po
+++ b/mtp_common/locale/cy/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-31 13:20+0100\n"
+"POT-Creation-Date: 2017-08-09 16:56+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Igor U <igor.ushkarev@digital.justice.gov.uk>, 2017\n"
 "Language-Team: Welsh (https://www.transifex.com/ministry-of-justice/teams/34553/cy/)\n"
@@ -36,60 +36,69 @@ msgstr "Gwnewch yn siŵr eich bod yn defnyddio porwr gwe modern megis Firefox ne
 msgid "Your browser failed a security check."
 msgstr "Mi wnaeth eich porwr fethu gwiriad diogelwch."
 
-#: auth/forms.py:21 templates/mtp_common/user_admin/list.html:41
+#: auth/forms.py:24 templates/mtp_common/user_admin/list.html:33
 #: user_admin/forms.py:16
 msgid "Username"
 msgstr "Enw defnyddiwr"
 
-#: auth/forms.py:22
+#: auth/forms.py:25
 msgid "Password"
 msgstr "Cyfrinair"
 
-#: auth/forms.py:25
+#: auth/forms.py:28
 msgid "You’ve entered an incorrect username and/or password"
 msgstr "Rydych wedi nodi enw defnyddiwr a/neu gyfrinair anghywir"
 
-#: auth/forms.py:26
+#: auth/forms.py:29
 msgid "You don’t have access to this application"
 msgstr "Nid oes gennych fynediad i'r adnodd hwn"
 
-#: auth/forms.py:27 auth/forms.py:79 auth/forms.py:125 user_admin/forms.py:27
+#: auth/forms.py:30 auth/forms.py:82 auth/forms.py:128 auth/forms.py:168
+#: user_admin/forms.py:27
 msgid "This service is currently unavailable"
 msgstr "Nid yw'r gwasanaeth hwn ar gael ar hyn o bryd"
 
-#: auth/forms.py:78
+#: auth/forms.py:81 auth/forms.py:167
 msgid "You’ve entered different passwords"
 msgstr "Rydych wedi nodi cyfrineiriau gwahanol"
 
-#: auth/forms.py:81
+#: auth/forms.py:84
 msgid "Old password"
 msgstr "Hen gyfrinair"
 
-#: auth/forms.py:83
+#: auth/forms.py:86 auth/forms.py:172
 msgid "New password"
 msgstr "Cyfrinair newydd"
 
-#: auth/forms.py:85
+#: auth/forms.py:88 auth/forms.py:174
 msgid "New password confirmation"
 msgstr "Cadarnhau eich cyfrinair newydd"
 
-#: auth/forms.py:127
+#: auth/forms.py:130
 msgid "Username or email address"
 msgstr "Enw defnyddiwr neu gyfeiriad e-bost"
 
-#: auth/views.py:21 user_admin/views.py:23
+#: auth/forms.py:166
+msgid "This link for resetting your password has expired"
+msgstr ""
+
+#: auth/forms.py:170
+msgid "Reset code"
+msgstr ""
+
+#: auth/views.py:24 user_admin/views.py:23
 msgid "Home"
 msgstr "Cartref"
 
-#: auth/views.py:106
+#: auth/views.py:109
 msgid "Logged out"
 msgstr "Rydych wedi allgofnodi"
 
-#: auth/views.py:140 auth/views.py:154
+#: auth/views.py:143 auth/views.py:171 auth/views.py:184
 msgid "Change password"
 msgstr "Newid cyfrinair"
 
-#: auth/views.py:183 auth/views.py:198
+#: auth/views.py:214 auth/views.py:229
 msgid "Reset password"
 msgstr "Ailosod cyfrinair"
 
@@ -202,6 +211,7 @@ msgid "Change your password"
 msgstr "Newid eich cyfrinair"
 
 #: templates/mtp_common/auth/password_change.html:8
+#: templates/mtp_common/auth/password_change_with_code.html:8
 #: templates/mtp_common/auth/reset-password.html:8
 msgid "Submit"
 msgstr "Anfon"
@@ -223,14 +233,22 @@ msgstr "Mae eich cyfrinair wedi cael ei newid."
 msgid "Return to the home page"
 msgstr "Dychwelyd i'r dudalen gartref"
 
+#: templates/mtp_common/auth/password_change_with_code.html:4
+#: templates/mtp_common/auth/password_change_with_code.html:7
+msgid "Set a new password"
+msgstr ""
+
 #: templates/mtp_common/auth/reset-password-done.html:4
+msgid "Your password reset request was successful"
+msgstr ""
+
 #: templates/mtp_common/auth/reset-password-done.html:7
-msgid "Your password was reset successfully"
-msgstr "Cafodd eich cyfrinair ei ailosod yn llwyddiannus"
+msgid "A password reset email has been sent to you"
+msgstr ""
 
 #: templates/mtp_common/auth/reset-password-done.html:12
-msgid "You will get an email with your new password."
-msgstr "Fe gewch e-bost gyda'ch cyfrinair newydd."
+msgid "Click on the link in the email and you will be able to create a new password."
+msgstr ""
 
 #: templates/mtp_common/auth/reset-password.html:4
 #: templates/mtp_common/auth/reset-password.html:7
@@ -375,7 +393,7 @@ msgid "All content is available under the <a href=\"%(url)s\" rel=\"license\">Op
 msgstr "Mae'r holl gynnwys ar gael dan delerau'r <a href=\"%(url)s\" rel=\"license\">Drwydded Llywodraeth Agored f3.0</a>, heblaw lle nodir yn wahanol"
 
 #: templates/mtp_common/user_admin/delete.html:15
-#: templates/mtp_common/user_admin/list.html:25
+#: templates/mtp_common/user_admin/list.html:17
 msgid "When you disable a user account, that user will be unable to log in."
 msgstr "Pan fyddwch yn analluogi cyfrif defnyddiwr, ni fydd y defnyddiwr hwnnw yn gallu mewngofnodi."
 
@@ -411,55 +429,55 @@ msgstr "Cysylltwch â ni os ydych angen ei newid."
 msgid "Manage user accounts"
 msgstr "Rheoli cyfrifon defnyddwyr"
 
-#: templates/mtp_common/user_admin/list.html:24
+#: templates/mtp_common/user_admin/list.html:16
 msgid "Add, view, edit or disable user accounts."
 msgstr "Ychwanegu, edrych ar, golygu neu analluogi cyfrifon defnyddwyr."
 
-#: templates/mtp_common/user_admin/list.html:29
+#: templates/mtp_common/user_admin/list.html:21
 msgid "If a user enters a wrong password too many times, they are locked out for a short period."
 msgstr "Os bydd defnyddiwr yn nodi cyfrinair anghywir nifer o weithiau, bydd yn cael ei gloi allan am gyfnod byr."
 
-#: templates/mtp_common/user_admin/list.html:30
+#: templates/mtp_common/user_admin/list.html:22
 msgid "You can allow them to log in now by clicking ‘Unlock’."
 msgstr "Gallwch ganiatáu iddynt fewngofnodi nawr drwy glicio ar 'Datgloi'."
 
-#: templates/mtp_common/user_admin/list.html:35
+#: templates/mtp_common/user_admin/list.html:27
 msgid "Add a new user"
 msgstr "Ychwanegu defnyddiwr newydd"
 
-#: templates/mtp_common/user_admin/list.html:42
+#: templates/mtp_common/user_admin/list.html:34
 msgid "Name"
 msgstr "Enw"
 
-#: templates/mtp_common/user_admin/list.html:43 user_admin/forms.py:20
+#: templates/mtp_common/user_admin/list.html:35 user_admin/forms.py:20
 msgid "Email"
 msgstr "E-bost"
 
-#: templates/mtp_common/user_admin/list.html:44
+#: templates/mtp_common/user_admin/list.html:36
 msgid "Can manage accounts"
 msgstr "Gallu rheoli cyfrifon"
 
-#: templates/mtp_common/user_admin/list.html:45
+#: templates/mtp_common/user_admin/list.html:37
 msgid "Actions"
 msgstr "Camau gweithredu"
 
-#: templates/mtp_common/user_admin/list.html:58
+#: templates/mtp_common/user_admin/list.html:50
 msgid "User can manage other accounts"
 msgstr "Gall y defnyddiwr reoli cyfrifon eraill"
 
-#: templates/mtp_common/user_admin/list.html:63
+#: templates/mtp_common/user_admin/list.html:55
 msgid "Edit"
 msgstr "Golygu"
 
-#: templates/mtp_common/user_admin/list.html:68
+#: templates/mtp_common/user_admin/list.html:60
 msgid "Enable"
 msgstr "Galluogi"
 
-#: templates/mtp_common/user_admin/list.html:72
+#: templates/mtp_common/user_admin/list.html:64
 msgid "Unlock"
 msgstr "Datgloi"
 
-#: templates/mtp_common/user_admin/list.html:76
+#: templates/mtp_common/user_admin/list.html:68
 msgid "Disable"
 msgstr "Analluogi"
 
@@ -630,3 +648,9 @@ msgstr "Ni fydd y defnyddiwr newydd wedi'i leoli mewn carchar penodol."
 #, python-format
 msgid "Edit user ‘%(username)s’"
 msgstr "Golygu defnyddiwr ‘%(username)s’"
+
+#~ msgid "Your password was reset successfully"
+#~ msgstr "Cafodd eich cyfrinair ei ailosod yn llwyddiannus"
+
+#~ msgid "You will get an email with your new password."
+#~ msgstr "Fe gewch e-bost gyda'ch cyfrinair newydd."

--- a/mtp_common/locale/en_GB/LC_MESSAGES/django.po
+++ b/mtp_common/locale/en_GB/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: mtp-common\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-31 13:20+0100\n"
+"POT-Creation-Date: 2017-08-09 16:56+0100\n"
 "PO-Revision-Date: 2016-11-04 10:00+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi.gov.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/ministry-of-justice/mtp/language/cy/)\n"
@@ -36,60 +36,69 @@ msgstr ""
 msgid "Your browser failed a security check."
 msgstr ""
 
-#: auth/forms.py:21 templates/mtp_common/user_admin/list.html:41
+#: auth/forms.py:24 templates/mtp_common/user_admin/list.html:33
 #: user_admin/forms.py:16
 msgid "Username"
 msgstr ""
 
-#: auth/forms.py:22
+#: auth/forms.py:25
 msgid "Password"
 msgstr ""
 
-#: auth/forms.py:25
+#: auth/forms.py:28
 msgid "You’ve entered an incorrect username and/or password"
 msgstr ""
 
-#: auth/forms.py:26
+#: auth/forms.py:29
 msgid "You don’t have access to this application"
 msgstr ""
 
-#: auth/forms.py:27 auth/forms.py:79 auth/forms.py:125 user_admin/forms.py:27
+#: auth/forms.py:30 auth/forms.py:82 auth/forms.py:128 auth/forms.py:168
+#: user_admin/forms.py:27
 msgid "This service is currently unavailable"
 msgstr ""
 
-#: auth/forms.py:78
+#: auth/forms.py:81 auth/forms.py:167
 msgid "You’ve entered different passwords"
 msgstr ""
 
-#: auth/forms.py:81
+#: auth/forms.py:84
 msgid "Old password"
 msgstr ""
 
-#: auth/forms.py:83
+#: auth/forms.py:86 auth/forms.py:172
 msgid "New password"
 msgstr ""
 
-#: auth/forms.py:85
+#: auth/forms.py:88 auth/forms.py:174
 msgid "New password confirmation"
 msgstr ""
 
-#: auth/forms.py:127
+#: auth/forms.py:130
 msgid "Username or email address"
 msgstr ""
 
-#: auth/views.py:21 user_admin/views.py:23
+#: auth/forms.py:166
+msgid "This link for resetting your password has expired"
+msgstr ""
+
+#: auth/forms.py:170
+msgid "Reset code"
+msgstr ""
+
+#: auth/views.py:24 user_admin/views.py:23
 msgid "Home"
 msgstr ""
 
-#: auth/views.py:106
+#: auth/views.py:109
 msgid "Logged out"
 msgstr ""
 
-#: auth/views.py:140 auth/views.py:154
+#: auth/views.py:143 auth/views.py:171 auth/views.py:184
 msgid "Change password"
 msgstr ""
 
-#: auth/views.py:183 auth/views.py:198
+#: auth/views.py:214 auth/views.py:229
 msgid "Reset password"
 msgstr ""
 
@@ -202,6 +211,7 @@ msgid "Change your password"
 msgstr ""
 
 #: templates/mtp_common/auth/password_change.html:8
+#: templates/mtp_common/auth/password_change_with_code.html:8
 #: templates/mtp_common/auth/reset-password.html:8
 msgid "Submit"
 msgstr ""
@@ -223,13 +233,21 @@ msgstr ""
 msgid "Return to the home page"
 msgstr ""
 
+#: templates/mtp_common/auth/password_change_with_code.html:4
+#: templates/mtp_common/auth/password_change_with_code.html:7
+msgid "Set a new password"
+msgstr ""
+
 #: templates/mtp_common/auth/reset-password-done.html:4
+msgid "Your password reset request was successful"
+msgstr ""
+
 #: templates/mtp_common/auth/reset-password-done.html:7
-msgid "Your password was reset successfully"
+msgid "A password reset email has been sent to you"
 msgstr ""
 
 #: templates/mtp_common/auth/reset-password-done.html:12
-msgid "You will get an email with your new password."
+msgid "Click on the link in the email and you will be able to create a new password."
 msgstr ""
 
 #: templates/mtp_common/auth/reset-password.html:4
@@ -375,7 +393,7 @@ msgid "All content is available under the <a href=\"%(url)s\" rel=\"license\">Op
 msgstr ""
 
 #: templates/mtp_common/user_admin/delete.html:15
-#: templates/mtp_common/user_admin/list.html:25
+#: templates/mtp_common/user_admin/list.html:17
 msgid "When you disable a user account, that user will be unable to log in."
 msgstr ""
 
@@ -411,55 +429,55 @@ msgstr ""
 msgid "Manage user accounts"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:24
+#: templates/mtp_common/user_admin/list.html:16
 msgid "Add, view, edit or disable user accounts."
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:29
+#: templates/mtp_common/user_admin/list.html:21
 msgid "If a user enters a wrong password too many times, they are locked out for a short period."
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:30
+#: templates/mtp_common/user_admin/list.html:22
 msgid "You can allow them to log in now by clicking ‘Unlock’."
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:35
+#: templates/mtp_common/user_admin/list.html:27
 msgid "Add a new user"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:42
+#: templates/mtp_common/user_admin/list.html:34
 msgid "Name"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:43 user_admin/forms.py:20
+#: templates/mtp_common/user_admin/list.html:35 user_admin/forms.py:20
 msgid "Email"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:44
+#: templates/mtp_common/user_admin/list.html:36
 msgid "Can manage accounts"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:45
+#: templates/mtp_common/user_admin/list.html:37
 msgid "Actions"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:58
+#: templates/mtp_common/user_admin/list.html:50
 msgid "User can manage other accounts"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:63
+#: templates/mtp_common/user_admin/list.html:55
 msgid "Edit"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:68
+#: templates/mtp_common/user_admin/list.html:60
 msgid "Enable"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:72
+#: templates/mtp_common/user_admin/list.html:64
 msgid "Unlock"
 msgstr ""
 
-#: templates/mtp_common/user_admin/list.html:76
+#: templates/mtp_common/user_admin/list.html:68
 msgid "Disable"
 msgstr ""
 

--- a/mtp_common/templates/mtp_common/auth/password_change_with_code.html
+++ b/mtp_common/templates/mtp_common/auth/password_change_with_code.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block page_title %}{% trans 'Set a new password' %} – {{ block.super }}{% endblock %}
+
+{% block inner_content %}
+  {% trans 'Set a new password' as form_title %}
+  {% trans 'Submit' as submit_text %}
+  {% include 'mtp_common/forms/generic.html' %}
+{% endblock %}

--- a/mtp_common/templates/mtp_common/auth/reset-password-done.html
+++ b/mtp_common/templates/mtp_common/auth/reset-password-done.html
@@ -1,15 +1,15 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block page_title %}{% trans 'Your password was reset successfully' %} – {{ block.super }}{% endblock %}
+{% block page_title %}{% trans 'Your password reset request was successful' %} – {{ block.super }}{% endblock %}
 
 {% block inner_content %}
-  <h1 class="heading-xlarge">{% trans 'Your password was reset successfully' %}</h1>
+  <h1 class="heading-xlarge">{% trans 'A password reset email has been sent to you' %}</h1>
   <div class="container">
     <div class="grid-row">
       <div class="column-two-thirds">
         <p>
-          {% trans 'You will get an email with your new password.' %}
+          {% trans 'Click on the link in the email and you will be able to create a new password.' %}
         </p>
         <p><a href="{{ cancel_url }}">{% trans 'Return to the home page' %}</a></p>
       </div>


### PR DESCRIPTION
This means that only the actual owner of the account can change their
password, and that they never have to enter an annoying random
password.