### PR TITLE
Rename service

### DIFF
--- a/mtp_common/app.py
+++ b/mtp_common/app.py
@@ -6,7 +6,7 @@ from mtp_common.forms import replace_default_error_messages
 
 class AppConfig(DjangoAppConfig):
     name = 'mtp_common'
-    verbose_name = _('Send money to a prisoner')
+    verbose_name = _('Prisoner money')
 
     def ready(self):
         replace_default_error_messages()

--- a/mtp_common/locale/cy/LC_MESSAGES/django.po
+++ b/mtp_common/locale/cy/LC_MESSAGES/django.po
@@ -1,10 +1,10 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-09 16:56+0100\n"
+"POT-Creation-Date: 2017-08-10 12:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Igor U <igor.ushkarev@digital.justice.gov.uk>, 2017\n"
 "Language-Team: Welsh (https://www.transifex.com/ministry-of-justice/teams/34553/cy/)\n"
@@ -14,11 +14,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3;\n"
 
-#: app.py:9 templates/mtp_common/auth/login.html:13
-#: templates/mtp_common/email_base.html:16 templates/mtp_common/mtp_base.html:6
-#: templates/mtp_common/mtp_base.html:62
-msgid "Send money to a prisoner"
-msgstr "Anfon arian at garcharor"
+#: app.py:9
+msgid "Prisoner money"
+msgstr ""
 
 #: auth/csrf.py:27 auth/csrf.py:30 auth/csrf.py:35
 msgid "Please try again."
@@ -200,6 +198,12 @@ msgstr "Nodwch 'mis' fel rhif"
 #: templates/mtp_common/auth/login.html:37
 msgid "Sign in"
 msgstr "Mewngofnodi"
+
+#: templates/mtp_common/auth/login.html:13
+#: templates/mtp_common/email_base.html:16 templates/mtp_common/mtp_base.html:6
+#: templates/mtp_common/mtp_base.html:62
+msgid "Send money to someone in prison"
+msgstr "Anfon arian at garcharor"
 
 #: templates/mtp_common/auth/login.html:44
 msgid "Forgotten your password?"
@@ -648,6 +652,9 @@ msgstr "Ni fydd y defnyddiwr newydd wedi'i leoli mewn carchar penodol."
 #, python-format
 msgid "Edit user ‘%(username)s’"
 msgstr "Golygu defnyddiwr ‘%(username)s’"
+
+#~ msgid "Send money to a prisoner"
+#~ msgstr "Anfon arian at garcharor"
 
 #~ msgid "Your password was reset successfully"
 #~ msgstr "Cafodd eich cyfrinair ei ailosod yn llwyddiannus"

--- a/mtp_common/locale/cy/LC_MESSAGES/djangojs.po
+++ b/mtp_common/locale/cy/LC_MESSAGES/djangojs.po
@@ -1,10 +1,10 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-02 17:47+0100\n"
+"POT-Creation-Date: 2017-08-10 12:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Igor U <igor.ushkarev@digital.justice.gov.uk>, 2017\n"
 "Language-Team: Welsh (https://www.transifex.com/ministry-of-justice/teams/34553/cy/)\n"

--- a/mtp_common/locale/en_GB/LC_MESSAGES/django.po
+++ b/mtp_common/locale/en_GB/LC_MESSAGES/django.po
@@ -1,10 +1,10 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""
 "Project-Id-Version: mtp-common\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-09 16:56+0100\n"
+"POT-Creation-Date: 2017-08-10 12:27+0100\n"
 "PO-Revision-Date: 2016-11-04 10:00+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi.gov.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/ministry-of-justice/mtp/language/cy/)\n"
@@ -14,10 +14,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: app.py:9 templates/mtp_common/auth/login.html:13
-#: templates/mtp_common/email_base.html:16 templates/mtp_common/mtp_base.html:6
-#: templates/mtp_common/mtp_base.html:62
-msgid "Send money to a prisoner"
+#: app.py:9
+msgid "Prisoner money"
 msgstr ""
 
 #: auth/csrf.py:27 auth/csrf.py:30 auth/csrf.py:35
@@ -199,6 +197,12 @@ msgstr ""
 #: templates/mtp_common/auth/login.html:15
 #: templates/mtp_common/auth/login.html:37
 msgid "Sign in"
+msgstr ""
+
+#: templates/mtp_common/auth/login.html:13
+#: templates/mtp_common/email_base.html:16 templates/mtp_common/mtp_base.html:6
+#: templates/mtp_common/mtp_base.html:62
+msgid "Send money to someone in prison"
 msgstr ""
 
 #: templates/mtp_common/auth/login.html:44

--- a/mtp_common/locale/en_GB/LC_MESSAGES/djangojs.po
+++ b/mtp_common/locale/en_GB/LC_MESSAGES/djangojs.po
@@ -1,10 +1,10 @@
-# Send money to a prisoner
+# Prisoner money
 # Copyright (C) Crown copyright (Ministry of Justice)
 msgid ""
 msgstr ""
 "Project-Id-Version: mtp-common\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-02 17:47+0100\n"
+"POT-Creation-Date: 2017-08-10 12:27+0100\n"
 "PO-Revision-Date: 2016-11-04 10:00+0000\n"
 "Last-Translator: Welsh Language Unit <welsh.language.unit.manager@hmcts.gsi.gov.uk>\n"
 "Language-Team: Welsh (http://www.transifex.com/ministry-of-justice/mtp/language/cy/)\n"

--- a/mtp_common/templates/mtp_common/auth/login.html
+++ b/mtp_common/templates/mtp_common/auth/login.html
@@ -10,7 +10,7 @@
     {% language_switch %}
     <h1 class="heading-xlarge">
       <span class="heading-secondary">
-        {% block auth_title %}{% trans 'Send money to a prisoner' %}{% endblock %}
+        {% block auth_title %}{% trans 'Send money to someone in prison' %}{% endblock %}
       </span>
       {% trans 'Sign in' %}
     </h1>

--- a/mtp_common/templates/mtp_common/email_base.html
+++ b/mtp_common/templates/mtp_common/email_base.html
@@ -13,7 +13,7 @@
             <img src="{{ static_url }}/mtp_common/images/govuk-header-logo.png" alt="GOV.UK">
           </td>
           <td style="padding-right: 30px; color: #fff; font-size: 20px; font-family: sans-serif;">
-            {% trans 'Send money to a prisoner' %}
+            {% trans 'Send money to someone in prison' %}
           </td>
         </tr>
       </table>

--- a/mtp_common/templates/mtp_common/maintenance-citizen.html
+++ b/mtp_common/templates/mtp_common/maintenance-citizen.html
@@ -3,7 +3,7 @@
 <!--[if gt IE 8]><!--><html lang="en"><!--<![endif]-->
 <head>
   <meta charset="utf-8" />
-  <title>Send money to a prisoner</title>
+  <title>Send money to someone in prison</title>
 
   <!--[if gt IE 8]><!-->
   <style>
@@ -907,7 +907,7 @@ button:focus,
       </div>
       <div class="header-proposition">
         <div class="content">
-          <a href="/" id="proposition-name">Send money to a prisoner</a>
+          <a href="/" id="proposition-name">Send money to someone in prison</a>
         </div>
       </div>
     </div>
@@ -922,7 +922,7 @@ button:focus,
         <div class="column-two-thirds">
           <p>This service is temporarily unavailable due to a technical problem.</p>
           <p>Our team is doing their best to get the service back online.</p>
-          <p>You can still <a href='https://www.gov.uk/staying-in-touch-with-someone-in-prison/sending-money'>send money to a prisoner by postal order, cheque or in the post.</a></p>
+          <p>You can still <a href='https://www.gov.uk/staying-in-touch-with-someone-in-prison/sending-money'>send money to someone in prison by postal order, cheque or in the post.</a></p>
         </div>
       </div>
     </div>

--- a/mtp_common/templates/mtp_common/maintenance.html
+++ b/mtp_common/templates/mtp_common/maintenance.html
@@ -3,7 +3,7 @@
 <!--[if gt IE 8]><!--><html lang="en"><!--<![endif]-->
 <head>
   <meta charset="utf-8" />
-  <title>Send money to a prisoner</title>
+  <title>Send money to someone in prison</title>
 
   <!--[if gt IE 8]><!-->
   <style>
@@ -907,7 +907,7 @@ button:focus,
       </div>
       <div class="header-proposition">
         <div class="content">
-          <a href="/" id="proposition-name">Send money to a prisoner</a>
+          <a href="/" id="proposition-name">Send money to someone in prison</a>
         </div>
       </div>
     </div>

--- a/mtp_common/templates/mtp_common/mtp_base.html
+++ b/mtp_common/templates/mtp_common/mtp_base.html
@@ -3,7 +3,7 @@
 {% load static %}
 {% load mtp_common %}
 
-{% block page_title %}{% trans 'Send money to a prisoner' %}{% endblock %}
+{% block page_title %}{% trans 'Send money to someone in prison' %}{% endblock %}
 
 {% block head %}
   {{ block.super }}
@@ -59,7 +59,7 @@
         <a href="#proposition-links" class="js-mtp-header-toggle menu print-hidden">{% trans 'Menu' %}</a>
       {% endif %}
       <nav id="proposition-menu">
-        <a href="{{ home_url }}" id="proposition-name">{% block proposition %}{% trans 'Send money to a prisoner' %}{% endblock %}</a>
+        <a href="{{ home_url }}" id="proposition-name">{% block proposition %}{% trans 'Send money to someone in prison' %}{% endblock %}</a>
         {% block proposition_menu %}{% endblock %}
       </nav>
     </div>


### PR DESCRIPTION
- "Send money to a prisoner" is now "Send money to someone in prison" for consistency
- use "Prisoner money" as the umbrella term in admin views etc