### PR TITLE
Add support for retrieving a bare Requests session object from auth module

### DIFF
--- a/mtp_common/api.py
+++ b/mtp_common/api.py
@@ -45,3 +45,30 @@ def retrieve_all_pages(api_endpoint, **kwargs):
         offset += page_size
 
     return loaded_results
+
+
+def retrieve_all_pages_for_path(session, path, **params):
+    """
+    Some MTP apis are paginated using Django Rest Framework's LimitOffsetPagination paginator,
+    this method loads all pages into a single results list
+    :param session: Requests Session object
+    :param path: URL path
+    :param params: additional URL params
+    """
+    page_size = getattr(settings, 'REQUEST_PAGE_SIZE', 20)
+    loaded_results = []
+
+    offset = 0
+    while True:
+        response = session.get(
+            path,
+            params=dict(limit=page_size, offset=offset, **params)
+        )
+        content = response.json()
+        count = content.get('count', 0)
+        loaded_results += content.get('results', [])
+        if len(loaded_results) >= count:
+            break
+        offset += page_size
+
+    return loaded_results

--- a/mtp_common/auth/exceptions.py
+++ b/mtp_common/auth/exceptions.py
@@ -1,6 +1,29 @@
-class Unauthorized(Exception):
+from requests.exceptions import HTTPError
+
+
+class ApiHttpError(HTTPError):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
+
+
+class HttpClientError(ApiHttpError):
     pass
 
 
-class Forbidden(Exception):
+class Unauthorized(HttpClientError):
+    pass
+
+
+class Forbidden(HttpClientError):
+    pass
+
+
+class HttpNotFoundError(HttpClientError):
+    pass
+
+
+class HttpServerError(ApiHttpError):
     pass

--- a/mtp_common/user_admin/forms.py
+++ b/mtp_common/user_admin/forms.py
@@ -35,7 +35,8 @@ class UserUpdateForm(GARequestErrorReportingMixin, forms.Form):
             del self.fields['role']
             del self.fields['user_admin']
         else:
-            managed_roles = api_client.get_connection(self.request).roles.get(managed=1).get('results', [])
+            response = api_client.get_api_session(self.request).get('roles/', params={'managed': 1})
+            managed_roles = response.json().get('results', [])
             initial_role = None
             role_choices = []
             for role in managed_roles:
@@ -64,7 +65,7 @@ class UserUpdateForm(GARequestErrorReportingMixin, forms.Form):
 
                 if self.create:
                     data['username'] = self.cleaned_data['username']
-                    api_client.get_connection(self.request).users().post(data)
+                    api_client.get_api_session(self.request).post('users/', json=data)
 
                     logger.info('Admin %(admin_username)s created user %(username)s' % {
                         'admin_username': admin_username,
@@ -76,7 +77,9 @@ class UserUpdateForm(GARequestErrorReportingMixin, forms.Form):
                     })
                 else:
                     username = self.initial['username']
-                    api_client.get_connection(self.request).users(username).patch(data)
+                    api_client.get_api_session(self.request).patch(
+                        'users/{username}/'.format(username=username), json=data
+                    )
 
                     logger.info('Admin %(admin_username)s edited user %(username)s' % {
                         'admin_username': admin_username,

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -275,23 +275,6 @@ class GetConnectionTestCase(SimpleTestCase):
 
 class GetApiSessionTestCase(GetConnectionTestCase):
 
-    def setUp(self):
-        """
-        Sets up a request mock object with
-        request.user.token == generated token.
-
-        It also defines the {base_url}/test/ endpoint which will be
-        used by all the test methods.
-        """
-        super().setUp()
-        self.request = mock.MagicMock(
-            user=mock.MagicMock(
-                token=generate_tokens()
-            )
-        )
-
-        self.test_endpoint = urljoin(settings.API_URL, 'test')
-
     def _test_failure(self):
         session = api_client.get_api_session(self.request)
         self.assertRaises(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -140,6 +140,16 @@ class GetConnectionTestCase(SimpleTestCase):
 
         self.test_endpoint = urljoin(settings.API_URL, 'test')
 
+    def _test_failure(self):
+        conn = api_client.get_connection(self.request)
+        self.assertRaises(
+            Unauthorized, conn.test.get
+        )
+
+    def _test_success(self):
+        conn = api_client.get_connection(self.request)
+        return conn.test.get()
+
     def test_without_logged_in_user_raises_unauthorized(self):
         """
         If request.user is None, the get_connection raises
@@ -175,11 +185,7 @@ class GetConnectionTestCase(SimpleTestCase):
             content_type='application/json'
         )
 
-        # test
-        conn = api_client.get_connection(self.request)
-        self.assertRaises(
-            Unauthorized, conn.test.get
-        )
+        self._test_failure()
 
     @responses.activate
     def test_invalid_access_token_raises_unauthorized(self):
@@ -191,10 +197,7 @@ class GetConnectionTestCase(SimpleTestCase):
             content_type='application/json'
         )
 
-        conn = api_client.get_connection(self.request)
-        self.assertRaises(
-            Unauthorized, conn.test.get
-        )
+        self._test_failure()
 
     @responses.activate
     def test_with_valid_access_token(self):
@@ -210,8 +213,7 @@ class GetConnectionTestCase(SimpleTestCase):
         )
 
         # should return the same generated body
-        conn = api_client.get_connection(self.request)
-        result = conn.test.get()
+        result = self._test_success()
 
         self.assertDictEqual(result, expected_response)
 
@@ -261,13 +263,53 @@ class GetConnectionTestCase(SimpleTestCase):
             content_type='application/json'
         )
 
-        # test
-        conn = api_client.get_connection(self.request)
-        result = conn.test.get()
+        result = self._test_success()
 
         self.assertDictEqual(result, expected_response)
         self.assertDictEqual(self.request.user.token, new_token)
         self.assertNotEqual(
             expired_token['access_token'],
             new_token['access_token']
+        )
+
+
+class GetApiSessionTestCase(GetConnectionTestCase):
+
+    def setUp(self):
+        """
+        Sets up a request mock object with
+        request.user.token == generated token.
+
+        It also defines the {base_url}/test/ endpoint which will be
+        used by all the test methods.
+        """
+        super().setUp()
+        self.request = mock.MagicMock(
+            user=mock.MagicMock(
+                token=generate_tokens()
+            )
+        )
+
+        self.test_endpoint = urljoin(settings.API_URL, 'test')
+
+    def _test_failure(self):
+        session = api_client.get_api_session(self.request)
+        self.assertRaises(
+            Unauthorized, session.get, 'test/'
+        )
+
+    def _test_success(self):
+        session = api_client.get_api_session(self.request)
+        response = session.get('test/')
+        return response.json()
+
+    def test_without_logged_in_user_raises_unauthorized(self):
+        """
+        If request.user is None, the get_api_session raises
+        Unauthorized.
+        """
+        self.request.user = None
+
+        self.assertRaises(
+            Unauthorized, api_client.get_api_session, self.request
         )


### PR DESCRIPTION
This allows one to use the session object to make requests directly
rather than going via the slumber wrapper all the time.

The ```MoJOAuth2Session``` replicates some slumber functionality, such as auto-raising for error HTTP statuses and holding a base URL so the caller only needs to specify the path. In contrast to slumber it does return the actual response object though, so need to call ```.json()``` to get the contents.