### PR TITLE
Change exception type from slumber to requests on user creation

### DIFF
--- a/mtp_common/user_admin/forms.py
+++ b/mtp_common/user_admin/forms.py
@@ -5,9 +5,9 @@ from django import forms
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from form_error_reporting import GARequestErrorReportingMixin
-from slumber.exceptions import HttpClientError
 
 from mtp_common.auth import api_client
+from mtp_common.auth.exceptions import HttpClientError
 
 logger = logging.getLogger('mtp')
 


### PR DESCRIPTION
As the user creation process now uses requests rather than
slumber to call the api, need to use the appropriate exception
type.