### PR TITLE
Log only a warning when mailgun error is for an invalid address

### DIFF
--- a/mtp_common/tasks.py
+++ b/mtp_common/tasks.py
@@ -66,7 +66,10 @@ def send_email(to, text_template, subject, context=None, html_template=None, fro
                 message = e.response.json()['message']
             except (AttributeError, TypeError, ValueError, KeyError):
                 message = 'Mailgun 400 response'
-            logger.exception(message)
+            if "'to' parameter is not a valid address" in message:
+                logger.warning(message)
+            else:
+                logger.exception(message)
             return
         if not spoolable_ctx.spooled or not retry_attempts:
             raise


### PR DESCRIPTION
Still log as an exception otherwise