### PR TITLE
Fix tear down of live server test case when testing remotely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - 3.5
 install:
-  - pip install -U setuptools pip wheel
+  - pip install -U setuptools wheel
   - pip install .
 script:
   - python run.py --verbosity 2 test

--- a/mtp_common/test_utils/functional_tests.py
+++ b/mtp_common/test_utils/functional_tests.py
@@ -123,6 +123,15 @@ class FunctionalTestCase(LiveServerTestCase, WebDriverControlMixin):
         else:
             super(FunctionalTestCase, cls).setUpClass()
 
+    @classmethod
+    def tearDownClass(cls):
+        remote_url = os.environ.get('DJANGO_TEST_REMOTE_INTEGRATION_URL', None)
+        if remote_url:
+            cls._tearDownClassInternal()
+            super(LiveServerTestCase, cls).tearDownClass()
+        else:
+            super(FunctionalTestCase, cls).tearDownClass()
+
     def setUp(self):
         if self.auto_load_test_data:
             self.load_test_data()


### PR DESCRIPTION
The `tearDownClass` method of `LiveServerTestCase` tries to clean
up the live server thread, which is not running if we are testing
against a remote application.