### PR TITLE
Add additional configuration options to pagination template tag

### DIFF
--- a/mtp_common/templates/mtp_common/includes/page-list.html
+++ b/mtp_common/templates/mtp_common/includes/page-list.html
@@ -10,7 +10,7 @@
           {% if not page_index %}
             …
           {% else %}
-            <a href="?{% if query_string %}{{ query_string }}&amp;{% endif %}page={{ page_index }}" {% if page == page_index %}class="mtp-page-list__current-page"{% endif %}>
+            <a href="?{% if query_string %}{{ query_string }}&amp;{% endif %}{{ page_param }}={{ page_index }}{% if bookmark %}#{{ bookmark }}{% endif %}" {% if page == page_index %}class="mtp-page-list__current-page"{% endif %}>
               {% if page_index != 1 %}
                 <span class="visually-hidden">{% trans 'Page' %} </span>
               {% endif %}

--- a/mtp_common/templatetags/mtp_common.py
+++ b/mtp_common/templatetags/mtp_common.py
@@ -173,7 +173,10 @@ def sub_nav(context):
 
 
 @register.inclusion_tag('mtp_common/includes/page-list.html')
-def page_list(page, page_count, query_string=None, end_padding=1, page_padding=2):
+def page_list(
+    page, page_count, query_string=None, end_padding=1, page_padding=2,
+    page_param='page', bookmark=None
+):
     if page_count < 7:
         pages_with_ellipses = range(1, page_count + 1)
     else:
@@ -196,6 +199,8 @@ def page_list(page, page_count, query_string=None, end_padding=1, page_padding=2
         'page_count': page_count,
         'page_range': pages_with_ellipses,
         'query_string': query_string,
+        'page_param': page_param,
+        'bookmark': bookmark
     }
 
 


### PR DESCRIPTION
It is now possible to specify the pagination query parameter and
add a hash-bookmark to the url. These were added to support having
multiple paginated lists on one page.