### PR TITLE
Add extra flake8 rules

### DIFF
--- a/mtp_common/api.py
+++ b/mtp_common/api.py
@@ -21,7 +21,7 @@ def api_errors_to_messages(request, error, fallback_text):
     """
     try:
         response_body = json.loads(error.content.decode('utf-8'))
-        for field, errors in response_body.items():
+        for _, errors in response_body.items():
             if isinstance(errors, list):
                 for error in errors:
                     messages.error(request, error)

--- a/mtp_common/auth/api_client.py
+++ b/mtp_common/auth/api_client.py
@@ -139,7 +139,7 @@ def get_api_session(request):
 
 def get_api_session_with_session(user, session):
     if not user:
-        raise Unauthorized(u'no such user')
+        raise Unauthorized('no such user')
 
     def token_saver(token, session, user):
         user.token = token

--- a/mtp_common/auth/views.py
+++ b/mtp_common/auth/views.py
@@ -51,7 +51,7 @@ def login(request, template_name=None,
     if request.user.is_authenticated:
         return HttpResponseRedirect(get_redirect_to())
 
-    if request.method == "POST":
+    if request.method == 'POST':
         form = authentication_form(request=request, data=request.POST)
         if form.is_valid():
 

--- a/mtp_common/build_tasks/executor.py
+++ b/mtp_common/build_tasks/executor.py
@@ -134,7 +134,7 @@ class ParameterGroup(collections.MutableMapping):
     """
 
     @classmethod
-    def from_callable(cls, func, ignored_parameters=set()):
+    def from_callable(cls, func, ignored_parameters=frozenset()):
         """
         Reads a function or method signature to produce a set of parameters
         """

--- a/mtp_common/forms/fields.py
+++ b/mtp_common/forms/fields.py
@@ -3,7 +3,7 @@ import datetime
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.timezone import now
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class SplitDateWidget(forms.MultiWidget):

--- a/mtp_common/templatetags/mtp_common.py
+++ b/mtp_common/templatetags/mtp_common.py
@@ -62,10 +62,10 @@ def labelled_data(label, value, tag='div', url=None):
     if url:
         value = format_html('<a href="{url}">{value}</a>', value=value, url=url)
     return format_html(
-        '''
+        """
         <div id="mtp-label-{element_id}" class="mtp-detail-label">{label}</div>
         <{tag} aria-labelledby="mtp-label-{element_id}">{value}</{tag}>
-        ''',
+        """,
         element_id=element_id, label=label, value=value, tag=tag
     )
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extras_require = {
     'testing': [
         'flake8>=3.7,<4',
         'pep8-naming>=0.8.2,<1',
+        'flake8-bugbear>=19.3,<20',
         'responses>=0.10,<1',
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ extras_require = {
         'flake8>=3.7,<4',
         'pep8-naming>=0.8.2,<1',
         'flake8-bugbear>=19.3,<20',
+        'flake8-quotes>=2.0.1,<3',
         'responses>=0.10,<1',
     ],
 }

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,8 @@ extras_require = {
         'pep8-naming>=0.8.2,<1',
         'flake8-bugbear>=19.3,<20',
         'flake8-quotes>=2.0.1,<3',
+        'flake8-blind-except>=0.1.1,<1',
+        'flake8-debugger>=3.1,<4',
         'responses>=0.10,<1',
     ],
 }

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -37,10 +37,10 @@ class NotificationTestCase(SimpleTestCase):
                 }]},
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' %}
-                ''',
+                """,
                 {'request': self.unauthenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()
@@ -59,10 +59,10 @@ class NotificationTestCase(SimpleTestCase):
                 }]},
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()
@@ -77,10 +77,10 @@ class NotificationTestCase(SimpleTestCase):
                 body='error', status=500,
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()
@@ -106,10 +106,10 @@ class NotificationTestCase(SimpleTestCase):
                 }]},
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target1' 'target2' %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()
@@ -128,17 +128,17 @@ class NotificationTestCase(SimpleTestCase):
                 }]},
             )
             self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()
@@ -166,17 +166,17 @@ class NotificationTestCase(SimpleTestCase):
                 }]},
             )
             self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' use_cache=False %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
             response = self.load_mocked_template(
-                '''
+                """
                 {% load mtp_common %}
                 {% notifications_box request 'target' use_cache=False %}
-                ''',
+                """,
                 {'request': self.authenticated_request()},
             )
         response_content = response.content.decode(response.charset).strip()

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -11,13 +11,13 @@ class TemplateTagTestCase(SimpleTestCase):
             def __str__(self):
                 return 'magic'
 
-        template = '''
+        template = """
         {% load mtp_common %}
         {% if magic_int in ints %}PASS1{% endif %}
         {% if magic_int|to_string in ints %}FAIL1{% endif %}
         {% if magic_int in strs %}FAIL2{% endif %}
         {% if magic_int|to_string in strs %}PASS2{% endif %}
-        '''
+        """
         response = self.load_mocked_template(template, {
             'magic_int': MagicInt(123),
             'ints': [123],
@@ -34,7 +34,7 @@ class TemplateTagTestCase(SimpleTestCase):
         class TestForm(forms.Form):
             test_field = forms.CharField()
 
-        template = '''
+        template = """
         {% load mtp_common %}
         {% with field=form|field_from_name:'missing_field' %}
             -{{ field.value }}-
@@ -42,7 +42,7 @@ class TemplateTagTestCase(SimpleTestCase):
         {% with field=form|field_from_name:'test_field' %}
             +{{ field.value }}+
         {% endwith %}
-        '''
+        """
         response = self.load_mocked_template(template, {
             'form': TestForm(data={
                 'test_field': 123
@@ -57,20 +57,20 @@ class TemplateTagTestCase(SimpleTestCase):
         sentry_dsn = 'http://sentry.example.com/123'
         mocked_sentry_client.get_public_dsn.return_value = sentry_dsn
 
-        template = '''
+        template = """
         {% load mtp_common %}
         {% sentry_js %}
-        '''
+        """
         response = self.load_mocked_template(template, {})
         html = response.content.decode('utf-8')
         self.assertIn(sentry_dsn, html)
         self.assertIn('Raven.config', html)
 
     def test_page_list(self):
-        template = '''
+        template = """
         {% load mtp_common %}
         {% page_list page=current_page page_count=pages query_string=query_string %}
-        '''
+        """
 
         def render(current_page, pages, query_string=''):
             context = {


### PR DESCRIPTION
This adds:

- `flake8-bugbear` to catch likely bugs and design problems
- `flake8-quotes` to make the use of quotes consistent
- `flake8-blind-except` to catch blind, catch-all except: statements
- `flake8-debugger` to catch pdb;idbp imports and set traces