### PR TITLE
Add support for new style when using tabbedpanel

### DIFF
--- a/mtp_common/assets-src/javascripts/modules/tabbed-panel.js
+++ b/mtp_common/assets-src/javascripts/modules/tabbed-panel.js
@@ -19,6 +19,7 @@ exports.TabbedPanel = {
     var $tabPanels = $tabContainer.find('.mtp-tabpanel');
     var $tabPanelContainer = $tabPanels.closest('.mtp-tabpanels');
     var tabCookieName = $tabContainer.data('tab-cookie-name');
+    var tabCollapsable = $tabContainer.data('tab-collapsable');
 
     function resetTabsAndPanels (allowTabFocus) {
       $tabButtons.attr({
@@ -46,17 +47,20 @@ exports.TabbedPanel = {
       var $tabPanel = $tabButton.data('mtp-tabpanel');
       var wasSelected = $tabButton.hasClass('mtp-tab--selected');
 
-      resetTabsAndPanels(wasSelected);
-
       $tabButton.focus();
       if (wasSelected) {
-        closed = true;
-        $tabContainer.addClass('mtp-tab-container--collapsed');
-        $tabPanelContainer.attr('aria-expanded', 'false');
-        if (tabCookieName) {
-          Cookies.remove(tabCookieName);
+        if (tabCollapsable) {
+          resetTabsAndPanels(true);
+          closed = true;
+          $tabContainer.addClass('mtp-tab-container--collapsed');
+          $tabPanelContainer.attr('aria-expanded', 'false');
+          if (tabCookieName) {
+            Cookies.remove(tabCookieName);
+          }
         }
       } else {
+        resetTabsAndPanels(false);
+
         closed = false;
         selectedIndex = $tabButtons.index($tabButton);
         $tabButton.attr({
@@ -121,6 +125,11 @@ exports.TabbedPanel = {
       var lastOpenTab = parseInt(Cookies.get(tabCookieName), 10);
       if ($.isNumeric(lastOpenTab) && lastOpenTab >= 0 && lastOpenTab < $tabButtons.length) {
         $tabButtons.eq(lastOpenTab).click().blur();
+      } else {
+        // if collapsing not allowed and first time on this page, expand first tab
+        if (!tabCollapsable) {
+          $tabButtons.eq(0).click().blur();
+        }
       }
     }
 

--- a/mtp_common/assets-src/stylesheets/elements/_tabbed-panel.scss
+++ b/mtp_common/assets-src/stylesheets/elements/_tabbed-panel.scss
@@ -75,3 +75,90 @@
     }
   }
 }
+
+
+// alternative version - inspired by the GOV.UK Design System https://design-system.service.gov.uk/components/tabs/
+
+.govuk-grey.mtp-tab-container {
+  $tab-spacing: 5px;
+  $tab-border-width: 3px;
+  $tab-border-colour: $grey-2;
+
+  .mtp-tab-wrapper {
+    display: block;
+
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    border-bottom: 1px solid $tab-border-colour;
+
+    &:after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+  }
+
+  .mtp-tab-item {
+    display: inline-block;
+  }
+
+  .mtp-tab {
+    margin-right: $tab-spacing;
+    padding: $tab-spacing * 2 $tab-spacing * 4;
+    background-color: $grey-4;
+
+    display: inline-block;
+    color: $page-colour;
+    text-align: center;
+    text-decoration: none;
+    color: $black;
+    background-color: $grey-4;
+    border: 0;
+
+    &:focus {
+      outline: 3px solid $focus-colour;
+    }
+
+    &.mtp-tab--selected {
+      margin-top: - $tab-spacing;
+      margin-bottom: -1px;
+
+      // 1px is compensation for border (otherwise we get a 1px shift)
+      padding-top: $tab-spacing * 3 - 1px;
+      padding-right: $tab-spacing * 4 - 1px;
+      padding-bottom: $tab-spacing * 3 + 1px;
+      padding-left: $tab-spacing * 4 - 1px;
+
+      border: 1px solid $tab-border-colour;
+      border-bottom: 0;
+      color: $black;
+      background-color: $white;
+    }
+
+    &.error-message {
+      color: $error-colour;
+    }
+  }
+
+  .mtp-tabpanels {
+    margin-top: 0;
+  }
+
+  .mtp-tabpanel {
+    padding-top: $tab-spacing * 6;
+    padding-right: $tab-spacing * 4;
+    padding-bottom: $tab-spacing * 6;
+    padding-left: $tab-spacing * 4;
+    border: 1px solid $tab-border-colour;
+    border-top: 0;
+
+    &--hidden {
+      display: none;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+}

--- a/mtp_common/templates/mtp_common/includes/tabbed-panel.html
+++ b/mtp_common/templates/mtp_common/includes/tabbed-panel.html
@@ -1,4 +1,4 @@
-<div class="mtp-tab-container mtp-tab-container--collapsed" data-tab-cookie-name="{{ cookie_name }}">
+<div class="mtp-tab-container {{ css_class }} mtp-tab-container--collapsed" data-tab-cookie-name="{{ cookie_name }}" data-tab-collapsable="{{ collapsable|yesno:"true,false" }}">
   {% spaceless %}
     <ul class="mtp-tab-wrapper" role="tablist" aria-label="{{ tab_label|default:_('Filter by') }}">
       {% for tab in tabs %}

--- a/mtp_common/templatetags/mtp_common.py
+++ b/mtp_common/templatetags/mtp_common.py
@@ -275,10 +275,28 @@ def notifications_box(request, *targets, **kwargs):
 class TabbedPanelNode(template.Node):
     template_name = 'mtp_common/includes/tabbed-panel.html'
 
-    def __init__(self, node_list, cookie_name=None, tab_label=None):
+    def __init__(
+        self,
+        node_list,
+        cookie_name=None,
+        tab_label=None,
+        collapsable=None,
+        css_class=None,
+    ):
+        """
+        Params:
+            - cookie_name: name of the cookie in which to hold the state (selected tab, collapsed or expanded etc.)
+            - tab_label: to be used as aria-label
+            - collapsable (default True): if the selected tab should collapse when re-selected
+            - css_class: (optional) extra css class to append to the container.
+                If `govuk-grey` is specified, a alternative style similar to the GOV.UK Design System is used.
+                Alternatively, you can specify any custom value and define your own css rules.
+        """
         self.node_list = node_list
         self.cookie_name = cookie_name
         self.tab_label = tab_label
+        self.collapsable = collapsable
+        self.css_class = css_class
 
     def render(self, context):
         tabs = []
@@ -306,8 +324,12 @@ class TabbedPanelNode(template.Node):
         other_content = other_nodes.render(context)
         cookie_name = self.cookie_name.resolve(context) if self.cookie_name else ''
         tab_label = self.tab_label.resolve(context) if self.tab_label else ''
+        collapsable = self.collapsable.resolve(context) if self.collapsable else True
+        css_class = self.css_class.resolve(context) if self.css_class else ''
         context.push()
         context['cookie_name'] = cookie_name
+        context['css_class'] = css_class
+        context['collapsable'] = collapsable
         context['tab_label'] = tab_label
         context['tabs'] = tabs
         context['tab_content'] = tab_content


### PR DESCRIPTION
This:
- adds the ability to disable the collapse functionality so that clicking on the same tab twice doesn't do anything. To do this, you can pass `collapsable=False` (default=True).
- adds support for a new optional tabbedpanel param `css_class` which is added to the container div when specified
- adds support for a new style similar to the one in the GOV.UK Design System by using the css_class `govuk-grey`

Example:
```
{% tabbedpanel cookie_name='<cookie-name>' collapsable=False tab_label='<label>' css_class='govuk-grey' %}

  {% paneltab name='<tab-name>' title='<title>' %}
    ...
  {% endpaneltab %}

  ...
{% endtabbedpanel %}
```

<img width="1031" alt="Screenshot 2019-07-30 at 15 21 01" src="https://user-images.githubusercontent.com/178865/62137385-c7233280-b2dd-11e9-8687-2a84987cee35.png">
