### PR TITLE
Add support logic for the Cloud Platform migration

### DIFF
--- a/mtp_common/cp_migration/constants.py
+++ b/mtp_common/cp_migration/constants.py
@@ -1,0 +1,9 @@
+import enum
+
+
+class CloudPlatformMigrationMode(enum.Enum):
+    """
+    Enum for the different modes in the Cloud Platform migration.
+    """
+    maintenance = 'Maintenance'
+    moved = 'We have moved'

--- a/mtp_common/cp_migration/middleware.py
+++ b/mtp_common/cp_migration/middleware.py
@@ -1,0 +1,52 @@
+from django.utils.deprecation import MiddlewareMixin
+from django.conf import settings
+
+from mtp_common.auth.models import MojAnonymousUser
+
+from mtp_common.cp_migration.views import get_maintenance_response, get_we_have_moved_response
+from mtp_common.cp_migration.constants import CloudPlatformMigrationMode
+
+
+def _get_migration_mode():
+    try:
+        return CloudPlatformMigrationMode[settings.CLOUD_PLATFORM_MIGRATION_MODE]
+    except (AttributeError, KeyError):
+        pass
+
+    return None
+
+
+class CloudPlatformMigrationMiddleware(MiddlewareMixin):
+    """
+    When migrating to Cloud Platform, this middleware overrides the default behaviour
+    and returns either a:
+    - maintenance page saying that the site offline whilst we update it
+    - a page saying that we have moved to a new url.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Cache the migration mode so that we don't have to calculate it all the time.
+        """
+        self.migration_mode = _get_migration_mode()
+        super().__init__(*args, **kwargs)
+
+    def process_request(self, request):
+        """
+        Returns an ad-hoc response if in maintenance or 'we have moved' mode;
+        otherwise, continue as usual.
+
+        It fails silently if no mode is specified or the actual value is not
+        one recognised by the system.
+        """
+        if not self.migration_mode:
+            return None
+
+        if self.migration_mode == CloudPlatformMigrationMode.maintenance:
+            request.user = MojAnonymousUser()
+            return get_maintenance_response(request)
+
+        if self.migration_mode == CloudPlatformMigrationMode.moved:
+            request.user = MojAnonymousUser()
+            return get_we_have_moved_response(request)
+
+        return None

--- a/mtp_common/cp_migration/views.py
+++ b/mtp_common/cp_migration/views.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.shortcuts import render
+from django.utils.cache import add_never_cache_headers
+
+
+def get_maintenance_response(request):
+    """
+    Returns a 503 response with no-cache header and retry-after header.
+    """
+    response = render(
+        request,
+        'mtp_common/cp_migration/maintenance.html',
+        status=503,
+    )
+    response['Retry-After'] = 5 * 60 * 60  # 5 hours
+    add_never_cache_headers(response)
+    return response
+
+
+def get_we_have_moved_response(request):
+    """
+    Returns a 200 response with details of the new url.
+    """
+    new_domain = getattr(settings, 'CLOUD_PLATFORM_MIGRATION_URL', '')
+    response = render(
+        request,
+        'mtp_common/cp_migration/we-have-moved.html',
+        context={
+            'new_url': f'{new_domain}{request.get_full_path()}',
+        },
+    )
+    return response

--- a/mtp_common/templates/mtp_common/cp_migration/maintenance.html
+++ b/mtp_common/templates/mtp_common/cp_migration/maintenance.html
@@ -1,0 +1,17 @@
+{% extends 'mtp_common/mtp_base.html' %}
+{% load i18n %}
+
+{% block page_title %}{% trans 'This service is currently not available' %}{% endblock %}
+
+{% block inner_content %}
+  <h1 class="heading-xlarge">{% trans 'This service is currently not available' %}</h1>
+
+  <div class="container">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <p>{% trans 'Please try again later.' %}</p>
+        <p>{% trans 'Sorry, we’re making some changes to this website.' %}</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/mtp_common/templates/mtp_common/cp_migration/we-have-moved.html
+++ b/mtp_common/templates/mtp_common/cp_migration/we-have-moved.html
@@ -1,0 +1,44 @@
+{% extends 'mtp_common/mtp_base.html' %}
+{% load i18n %}
+
+{% block head %}
+  {{ block.super }}
+  <!--[if !IE 8]><!-->
+  <meta http-equiv="refresh" content="5;URL={{ new_url }}">
+  <!--<![endif]-->
+{% endblock %}
+
+{% block page_title %}{% trans 'We have moved' %}{% endblock %}
+
+{% block sub_nav %}
+  {{ block.super }}
+
+  <!--[if IE 8]>
+  <aside class="mtp-ie-support-banner">
+    <div>
+      <header class="heading-large">{% trans 'Change to Firefox to continue using this service' %}</header>
+      <p class="font-medium">{% blocktrans %}
+        You cannot use this service using your current browser, please open {{ new_url }} in Firefox.
+        {% endblocktrans %}
+      </p>
+    </div>
+  </aside>
+  <![endif]-->
+{% endblock %}
+
+{% block inner_content %}
+<!--[if !IE 8]><!-->
+  <h1 class="heading-xlarge">{% trans 'We have moved!' %}</h1>
+
+  <div class="container">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <p>
+          {% trans 'You will be automatically redirected to the site in 5 seconds.' %}
+          <br />{% blocktrans %}- or if you are impatient, <a href="{{ new_url }}">click here</a>.{% endblocktrans %}
+        </p>
+      </div>
+    </div>
+  </div>
+<!--<![endif]-->
+{% endblock %}

--- a/tests/test_cp_migration.py
+++ b/tests/test_cp_migration.py
@@ -1,0 +1,71 @@
+from django.test import SimpleTestCase
+from django.test.utils import modify_settings, override_settings
+from django.urls import reverse
+
+from mtp_common.cp_migration.constants import CloudPlatformMigrationMode
+
+
+@modify_settings(
+    MIDDLEWARE={
+        'append': 'mtp_common.cp_migration.middleware.CloudPlatformMigrationMiddleware',
+    },
+)
+class CloudPlatformMigrationMiddlewareTestCase(SimpleTestCase):
+    """
+    Test cases for CloudPlatformMigrationMiddleware.
+    """
+
+    def test_absent_mode_gets_ignored(self):
+        """
+        Test that if settings doesn't define any `CLOUD_PLATFORM_MIGRATION_MODE`, the system
+        doesn't do anything.
+        """
+        response = self.client.get(reverse('dummy'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, b'DUMMY')
+
+    def test_invalid_mode_gets_ignored(self):
+        """
+        Test that if settings.CLOUD_PLATFORM_MIGRATION_MODE is not a recognised mode, the system
+        doesn't do anything.
+        """
+        scenarios = [
+            'invalid',
+            '',
+            None,
+        ]
+        for scenario in scenarios:
+            with override_settings(CLOUD_PLATFORM_MIGRATION_MODE=scenario):
+                response = self.client.get(reverse('dummy'))
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.content, b'DUMMY')
+
+    @override_settings(CLOUD_PLATFORM_MIGRATION_MODE=CloudPlatformMigrationMode.maintenance.name)
+    def test_maintenance_mode(self):
+        """
+        Test that if settings.CLOUD_PLATFORM_MIGRATION_MODE == maintenance, a 503 response is returned.
+        """
+        response = self.client.get(reverse('dummy'))
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response['cache-control'],
+            'max-age=0, no-cache, no-store, must-revalidate',
+        )
+        self.assertEqual(
+            response['retry-after'],
+            '18000',
+        )
+
+    @override_settings(
+        CLOUD_PLATFORM_MIGRATION_MODE=CloudPlatformMigrationMode.moved.name,
+        CLOUD_PLATFORM_MIGRATION_URL='https://new-dummy',
+    )
+    def test_we_have_moved_mode(self):
+        """
+        Test that if settings.CLOUD_PLATFORM_MIGRATION_MODE == moved, a 200 response is returned
+        with details of the new url.
+        """
+        full_path = f"{reverse('dummy')}?param=value"
+        response = self.client.get(full_path)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f'https://new-dummy{full_path}')


### PR DESCRIPTION
This adds a new middleware that overrides the default request handlers and returns a maintenance page if `settings.CLOUD_PLATFORM_MIGRATION_MODE = 'maintenance'` or a page
saying that we have moved to a different domain if `settings.CLOUD_PLATFORM_MIGRATION_MODE = 'moved'`.

The template for the 'we have moved' mode, automatically redirects to the new url unless the browser is IE8.
The refresh meta is not really recommended by W3C but none of the alternatives are better: redirect in js (with the same issues) or don't redirect and ask users to click on the link instead.

The pages have not been designed yet.
At the moment they look like the ones below:

**Maintenance mode**
<img width="991" alt="Screenshot 2019-09-23 at 15 48 37" src="https://user-images.githubusercontent.com/178865/65436175-a2e55d00-de19-11e9-8341-78fc8582553f.png">

**We have moved mode NOT IE8**
<img width="998" alt="Screenshot 2019-09-23 at 15 31 50" src="https://user-images.githubusercontent.com/178865/65436206-b2fd3c80-de19-11e9-8540-5497b55d71d1.png">

**We have moved mode IE8**
<img width="509" alt="Screenshot 2019-09-23 at 15 48 18" src="https://user-images.githubusercontent.com/178865/65436242-c1e3ef00-de19-11e9-939c-0273c5744166.png">
