### PR TITLE
Lazy init DatePicker.js language strings

### DIFF
--- a/mtp_common/assets-src/javascripts/modules/date-picker.js
+++ b/mtp_common/assets-src/javascripts/modules/date-picker.js
@@ -195,12 +195,6 @@ MTPDatePicker.prototype.drawCalendar = function () {
   }
 };
 
-MTPDatePicker.prototype.monthLabels = [
-  django.gettext('January'), django.gettext('February'), django.gettext('March'), django.gettext('April'),
-  django.gettext('May'), django.gettext('June'), django.gettext('July'), django.gettext('August'),
-  django.gettext('September'), django.gettext('October'), django.gettext('November'), django.gettext('December')
-];
-
 exports.DatePicker = {
   selector: '.mtp-date-picker__control',
   $calendar: null,
@@ -210,6 +204,13 @@ exports.DatePicker = {
     if ($controls.length === 0) {
       return;
     }
+
+    MTPDatePicker.prototype.monthLabels = [
+      django.gettext('January'), django.gettext('February'), django.gettext('March'), django.gettext('April'),
+      django.gettext('May'), django.gettext('June'), django.gettext('July'), django.gettext('August'),
+      django.gettext('September'), django.gettext('October'), django.gettext('November'), django.gettext('December')
+    ];
+
     var picker = new MTPDatePicker();
     $controls.each(function () {
       var $control = $(this);


### PR DESCRIPTION
This moves the initialisation of language strings to the init method of MTPDatePicker so that it doesn't create any problems if the calling template doesn't define the django js global object.