### PR TITLE
Reset margin of h1 in notification boxes

### DIFF
--- a/mtp_common/assets-src/stylesheets/internal/_notifications.scss
+++ b/mtp_common/assets-src/stylesheets/internal/_notifications.scss
@@ -4,6 +4,10 @@
   border-left: 6px solid $light-blue;
   @include core-19;
 
+  h1 {
+    margin: 0;
+  }
+
   .mtp-notification__headline {
     position: relative;
     display: block;


### PR DESCRIPTION
This makes sure the h1 in notification boxes has zero margin now that the public-facing service is using this feature as well.