### PR TITLE
Nomis Elite2 API

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -95,6 +95,8 @@ def setup_django_for_testing(_: Context):
         LOGIN_URL=reverse_lazy('login'),
         LOGOUT_URL=reverse_lazy('logout'),
         LOGIN_REDIRECT_URL=reverse_lazy('dummy'),
+
+        # TODO: Remove once all apps move to NOMIS Elite2
         NOMIS_API_BASE_URL='https://noms-api-dev.local/nomisapi/',
         NOMIS_API_CLIENT_TOKEN='hello',
         NOMIS_API_PRIVATE_KEY=(
@@ -104,6 +106,7 @@ def setup_django_for_testing(_: Context):
             'TUeoge9H2N/cCafyhCKdFRdQF9lYB2jB+A==\n'
             '-----END EC PRIVATE KEY-----\n'
         ),  # this key is just for tests, doesn't do anything
+
         NOMIS_ELITE_CLIENT_ID='mtp',
         NOMIS_ELITE_CLIENT_SECRET='mtp-secret',
         NOMIS_ELITE_BASE_URL='https://noms-api-dev.local',

--- a/build_tasks.py
+++ b/build_tasks.py
@@ -86,6 +86,11 @@ def setup_django_for_testing(_: Context):
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
             'django.middleware.security.SecurityMiddleware',
         ),
+        CACHES={
+            'default': {
+                'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+            },
+        },
         CSRF_FAILURE_VIEW='mtp_common.auth.csrf.csrf_failure',
         LOGIN_URL=reverse_lazy('login'),
         LOGOUT_URL=reverse_lazy('logout'),
@@ -99,6 +104,9 @@ def setup_django_for_testing(_: Context):
             'TUeoge9H2N/cCafyhCKdFRdQF9lYB2jB+A==\n'
             '-----END EC PRIVATE KEY-----\n'
         ),  # this key is just for tests, doesn't do anything
+        NOMIS_ELITE_CLIENT_ID='mtp',
+        NOMIS_ELITE_CLIENT_SECRET='mtp-secret',
+        NOMIS_ELITE_BASE_URL='https://noms-api-dev.local',
     )
     django.setup()
 

--- a/mtp_common/auth/__init__.py
+++ b/mtp_common/auth/__init__.py
@@ -117,8 +117,11 @@ def logout(request):
         request.user = MojAnonymousUser()
 
 
-def urljoin(base, *parts):
-    return '/'.join([s.strip('/') for s in [base] + list(parts)]) + '/'
+def urljoin(base, *parts, trailing_slash=True):
+    url = '/'.join([s.strip('/') for s in [base] + list(parts)])
+    if trailing_slash:
+        url += '/'
+    return url
 
 
 def refresh_user_data(request, api_session=None):

--- a/mtp_common/nomis.py
+++ b/mtp_common/nomis.py
@@ -179,6 +179,7 @@ class BaseNomisConnector(ABC):
 class LegacyNomisConnector(BaseNomisConnector):
     """
     Connector for legacy NOMIS auth and API.
+    TODO: Remove once all apps move to NOMIS Elite2
     """
 
     def get_client_token(self):
@@ -320,6 +321,7 @@ class EliteNomisConnector(BaseNomisConnector):
 def _get_connector():
     """
     :return: the best NOMIS connector that can be used.
+    TODO: Remove once all apps move to NOMIS Elite2
     """
     elite_connector = EliteNomisConnector()
     if elite_connector.can_access_nomis():

--- a/mtp_common/nomis.py
+++ b/mtp_common/nomis.py
@@ -1,56 +1,147 @@
 import datetime
 import logging
 import time
+from abc import ABC, abstractmethod
 from urllib.parse import quote_plus
 
 from django.conf import settings
-from django.utils.dateparse import parse_datetime
-from django.utils.timezone import now
 import jwt
 import requests
 from requests.exceptions import ConnectionError
 
-from mtp_common.auth import api_client, urljoin
-from mtp_common.auth.exceptions import HttpNotFoundError
+from mtp_common.auth import urljoin
 
 logger = logging.getLogger('mtp')
 
 
-def can_access_nomis():
-    return bool(
-        settings.NOMIS_API_BASE_URL and settings.NOMIS_API_PRIVATE_KEY and
-        get_client_token()
-    )
-
-
-client_token = None
-
-
-def get_client_token():
+class BaseNomisConnector(ABC):
     """
-    Requests and stores the NOMIS API client token from mtp-api
+    Abstract class that connects to NOMIS; to be sublassed.
     """
-    if getattr(settings, 'NOMIS_API_CLIENT_TOKEN', ''):
-        return settings.NOMIS_API_CLIENT_TOKEN
-    global client_token
-    if not client_token or client_token['expires'] and client_token['expires'] - now() < datetime.timedelta(days=1):
-        session = None
+
+    @abstractmethod
+    def build_nomis_api_url(self, path):
+        """
+        :return: the url to the API endpoint defined by `path`.
+        :param path: string defining the endpoint e.g. '/some/endpoint'
+        """
+
+    @abstractmethod
+    def build_request_api_headers(self):
+        """
+        :return: dict with headers to used in calls to the NOMIS API.
+        """
+
+    @abstractmethod
+    def can_access_nomis(self):
+        """
+        :return: True if this class can connect to NOMIS.
+        """
+
+    def request(self, verb, path, params=None, json=None, timeout=15, retries=0, session=None):
+        """
+        Makes a request call to NOMIS.
+        You probably want to use the `get` or the `post` methods instead.
+        """
+        session_or_module = session or requests
+
+        method = getattr(session_or_module, verb)
+        should_retry = False
         try:
-            session = api_client.get_authenticated_api_session(settings.TOKEN_RETRIEVAL_USERNAME,
-                                                               settings.TOKEN_RETRIEVAL_PASSWORD)
-            client_token = session.get('/tokens/nomis/').json()
-        except (requests.RequestException, HttpNotFoundError, ValueError, AttributeError):
-            logger.exception('Cannot load NOMIS API client token')
-            return None
-        finally:
-            if session and getattr(session, 'access_token', None):
-                api_client.revoke_token(session.access_token)
-        if client_token.get('expires'):
-            client_token['expires'] = parse_datetime(client_token['expires'])
-            if client_token['expires'] < now():
-                logger.error('NOMIS API client token from mtp-api had expired')
-                return None
-    return client_token['token']
+            response = method(
+                self.build_nomis_api_url(path),
+                headers=self.build_request_api_headers(),
+                timeout=timeout,
+                params=params,
+                json=json,
+            )
+        except ConnectionError as e:
+            if retries > 0:
+                should_retry = True
+            else:
+                raise e
+        else:
+            if response.status_code >= 500 and retries > 0:
+                should_retry = True
+
+        if should_retry:
+            return self.request(
+                verb,
+                path,
+                params=params,
+                json=json,
+                timeout=timeout,
+                retries=retries-1,
+                session=session,
+            )
+
+        response.raise_for_status()
+        if response.status_code != requests.codes.no_content:
+            return response.json()
+
+        return {
+            'status_code': response.status_code,
+        }
+
+    def get(self, path, params=None, timeout=15, retries=0, session=None):
+        """
+        Makes a GET request to NOMIS.
+        """
+        if params:
+            params = {
+                param: params[param]
+                for param in params
+                if params[param] is not None
+            }
+        return self.request('get', path, params=params, timeout=timeout, retries=retries, session=session)
+
+    def post(self, path, data=None, timeout=15, retries=0, session=None):
+        """
+        Makes a POST request to NOMIS.
+        """
+        return self.request('post', path, json=data, timeout=timeout, retries=retries, session=session)
+
+
+class LegacyNomisConnector(BaseNomisConnector):
+    """
+    Connector for legacy NOMIS auth and API.
+    """
+
+    def get_client_token(self):
+        return getattr(settings, 'NOMIS_API_CLIENT_TOKEN', None)
+
+    def build_nomis_api_url(self, path):
+        return urljoin(settings.NOMIS_API_BASE_URL, path)
+
+    def build_request_api_headers(self):
+        encoded = jwt.encode(
+            {
+                'iat': int(time.time()),
+                'token': self.get_client_token(),
+            },
+            settings.NOMIS_API_PRIVATE_KEY,
+            'ES256',
+        )
+        bearer_token = encoded.decode('utf8')
+        return {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {bearer_token}',
+        }
+
+    def can_access_nomis(self):
+        return bool(
+            settings.NOMIS_API_BASE_URL
+            and settings.NOMIS_API_PRIVATE_KEY
+            and self.get_client_token()
+        )
+
+
+connector = LegacyNomisConnector()
+
+
+def can_access_nomis():
+    return connector.can_access_nomis()
 
 
 def convert_date_param(param):
@@ -61,74 +152,8 @@ def convert_date_param(param):
     return None
 
 
-def generate_request_headers():
-    encoded = jwt.encode(
-        {'iat': int(time.time()), 'token': get_client_token()},
-        settings.NOMIS_API_PRIVATE_KEY, 'ES256'
-    )
-    bearer_token = encoded.decode('utf8')
-    return {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json',
-        'Authorization': 'Bearer %s' % bearer_token
-    }
-
-
-def build_nomis_url(path):
-    return urljoin(settings.NOMIS_API_BASE_URL, path)
-
-
-def get(path, params=None, timeout=15, retries=0, session=None):
-    if params:
-        params = {
-            param: params[param] for param in params
-            if params[param] is not None
-        }
-    session_or_module = session or requests
-    try:
-        response = session_or_module.get(
-            build_nomis_url(path),
-            params=params,
-            headers=generate_request_headers(),
-            timeout=timeout
-        )
-    except ConnectionError as e:
-        if retries > 0:
-            return get(path, params, timeout, retries-1, session=session)
-        raise e
-    if response.status_code >= 500 and retries > 0:
-        return get(path, params, timeout, retries-1, session=session)
-
-    response.raise_for_status()
-    if response.status_code != requests.codes.no_content:
-        return response.json()
-    return {'status_code': response.status_code}
-
-
-def post(path, data=None, timeout=15, retries=0, session=None):
-    session_or_module = session or requests
-    try:
-        response = session_or_module.post(
-            build_nomis_url(path),
-            json=data,
-            headers=generate_request_headers(),
-            timeout=timeout
-        )
-    except ConnectionError as e:
-        if retries > 0:
-            return post(path, data, timeout, retries-1, session=session)
-        raise e
-    if response.status_code >= 500 and retries > 0:
-        return post(path, data, timeout, retries-1, session=session)
-
-    response.raise_for_status()
-    if response.status_code != requests.codes.no_content:
-        return response.json()
-    return {'status_code': response.status_code}
-
-
 def get_account_balances(prison_id, prisoner_number, retries=0, session=None):
-    return get(
+    return connector.get(
         '/prison/{prison_id}/offenders/{prisoner_number}/accounts'.format(
             prison_id=quote_plus(prison_id),
             prisoner_number=quote_plus(prisoner_number)
@@ -143,7 +168,7 @@ def get_transaction_history(prison_id, prisoner_number, account_code,
         'from_date': convert_date_param(from_date),
         'to_date': convert_date_param(to_date),
     }
-    return get(
+    return connector.get(
         '/prison/{prison_id}/offenders/{prisoner_number}/accounts/{account_code}/transactions'.format(
             prison_id=quote_plus(prison_id),
             prisoner_number=quote_plus(prisoner_number),
@@ -162,7 +187,7 @@ def create_transaction(prison_id, prisoner_number, amount, record_id,
         'client_transaction_id': str(record_id),
         'client_unique_ref': str(record_id)
     }
-    return post(
+    return connector.post(
         '/prison/{prison_id}/offenders/{prisoner_number}/transactions'.format(
             prison_id=quote_plus(prison_id),
             prisoner_number=quote_plus(prisoner_number)
@@ -172,7 +197,7 @@ def create_transaction(prison_id, prisoner_number, amount, record_id,
 
 
 def get_photograph_data(prisoner_number, retries=0, session=None):
-    result = get(
+    result = connector.get(
         '/offenders/{prisoner_number}/image'.format(
             prisoner_number=quote_plus(prisoner_number)
         ),
@@ -183,7 +208,7 @@ def get_photograph_data(prisoner_number, retries=0, session=None):
 
 
 def get_location(prisoner_number, retries=0, session=None):
-    result = get(
+    result = connector.get(
         '/offenders/{prisoner_number}/location'.format(
             prisoner_number=quote_plus(prisoner_number)
         ),

--- a/mtp_common/test_utils/__init__.py
+++ b/mtp_common/test_utils/__init__.py
@@ -1,5 +1,9 @@
 from contextlib import contextmanager
+from unittest import mock
 import logging
+
+from django.conf import settings
+from django.core import cache as django_cache
 
 
 @contextmanager
@@ -9,3 +13,19 @@ def silence_logger(name='mtp', level=logging.CRITICAL):
     logger.setLevel(level)
     yield
     logger.setLevel(old_level)
+
+
+@contextmanager
+def local_memory_cache():
+    """Configure settings.CACHES to use LocMemCache."""
+    with mock.patch.dict(
+        settings.CACHES['default'],
+        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
+    ):
+        cache_handler = django_cache.CacheHandler()
+
+        with mock.patch.object(django_cache, 'caches', cache_handler):
+            try:
+                yield
+            finally:
+                cache_handler['default'].clear()


### PR DESCRIPTION
This:
- adds the concept of NOMIS connectors so that we can have the old legacy and the new Elite2 one at the same time
- introduces a few handy functions like request_retry to automatically retrying a call

Re. NOMIS Elite2:
- it caches the token so that it doesn't have to be obtained at every request
- if an API call returns 401, it deletes the cached token and retry again just to make sure the token wasn't the cause
- the old logic of getting the legacy NOMIS token from the API if one can't be found in settings is gone as we're currently not using it and it's not going to be used with the new logic.