### PR TITLE
Add function to get current pod details

### DIFF
--- a/mtp_common/stack.py
+++ b/mtp_common/stack.py
@@ -1,12 +1,9 @@
 import os
 
-import boto3
-from botocore.exceptions import ClientError
 from django.conf import settings
 from kubernetes import client as k8s_client
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException, load_incluster_config
-import requests
 
 
 class StackException(Exception):
@@ -17,63 +14,9 @@ class StackInterrogationException(StackException):
     pass
 
 
-class InstanceNotInAsgException(StackException):
-    pass
-
-
-def is_first_instance():
+def is_first_instance(current_pod_name=None):
     """
-    Returns True if application is "first". Used to run commands only once in load-balanced environments.
-    """
-    if os.environ.get('KUBERNETES_SERVICE_HOST'):
-        return is_first_instance_k8s()
-    return is_first_instance_aws()
-
-
-def is_first_instance_aws():
-    """
-    Returns True if the current instance is the first instance in the ASG group,
-    sorted by instance_id.
-    """
-    try:
-        # get instance id and aws region
-        instance_details = requests.get('http://169.254.169.254/latest/dynamic/instance-identity/document',
-                                        timeout=5).json()
-        instance_id = instance_details['instanceId']
-        instance_region = instance_details['region']
-    except (requests.RequestException, ValueError, KeyError) as e:
-        raise StackInterrogationException(e)
-
-    try:
-        # get instance's autoscaling group
-        autoscaling_client = boto3.client('autoscaling', region_name=instance_region)
-        response = autoscaling_client.describe_auto_scaling_instances(InstanceIds=[instance_id])
-        assert len(response['AutoScalingInstances']) == 1
-        autoscaling_group = response['AutoScalingInstances'][0]['AutoScalingGroupName']
-    except ClientError as e:
-        raise StackInterrogationException(e)
-    except AssertionError:
-        raise InstanceNotInAsgException()
-
-    try:
-        # list in-service instances in autoscaling group
-        # instances being launched or terminated should not be considered
-        response = autoscaling_client.describe_auto_scaling_groups(AutoScalingGroupNames=[autoscaling_group])
-        assert len(response['AutoScalingGroups']) == 1
-        autoscaling_group_instance_ids = sorted(
-            instance['InstanceId']
-            for instance in response['AutoScalingGroups'][0]['Instances']
-            if instance['LifecycleState'] == 'InService'
-        )
-    except (ClientError, AssertionError) as e:
-        raise StackInterrogationException(e)
-
-    return bool(autoscaling_group_instance_ids and autoscaling_group_instance_ids[0] == instance_id)
-
-
-def is_first_instance_k8s(current_pod_name=None):
-    """
-    Returns True if the current pod is the first replica in Kubernetes cluster.
+    Returns True if the current pod is the first replica in cloud platform cluster
     """
     current_pod_name = current_pod_name or os.environ.get('POD_NAME')
     if not current_pod_name:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ install_requires = [
     'govuk-bank-holidays>=0.3',
     'cryptography>=2.3,<3',
     'PyJWT>=1.7,<2',
-    'boto3>=1.5,<2',
     'kubernetes>=9,<10',  # corresponds to server version 1.13
     'prometheus_client>=0.6,<1',
 ]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,22 +1,22 @@
 import os
 from unittest import mock
 
+from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException
 
-from mtp_common.stack import StackInterrogationException, is_first_instance
+from mtp_common.stack import StackInterrogationException, is_first_instance, get_current_pod
 from tests.utils import SimpleTestCase
 
 
 class StackTestCase(SimpleTestCase):
     def setup_k8s_responses(self, mock_config, mock_client, pod_name):
-        from kubernetes.client.configuration import Configuration
-
         os.environ['KUBERNETES_SERVICE_HOST'] = '127.0.0.1'
         os.environ['KUBERNETES_SERVICE_PORT'] = '9988'
         os.environ['POD_NAME'] = pod_name
         configuration = Configuration()
         configuration.host = 'http://127.0.0.1:9988'
+        configuration.api_key = {'authorization': 'bearer T0ken'}
         Configuration.set_default(configuration)
         mock_config.return_value = None
         pod1 = mock.MagicMock()
@@ -30,7 +30,7 @@ class StackTestCase(SimpleTestCase):
         pod3.status.phase = 'Terminating'
         mock_client.CoreV1Api().list_namespaced_pod().items = [pod1, pod2, pod3]
 
-    @mock.patch('mtp_common.stack.k8s_client')
+    @mock.patch('mtp_common.stack.client')
     @mock.patch('mtp_common.stack.load_incluster_config')
     def test_first_in_k8s(self, mock_config, mock_client):
         self.setup_k8s_responses(mock_config, mock_client, pod_name='api-123')
@@ -39,19 +39,19 @@ class StackTestCase(SimpleTestCase):
         self.assertEqual(kwargs['namespace'], 'money-to-prisoners-test')
         self.assertEqual(kwargs['label_selector'], 'app=common')
 
-    @mock.patch('mtp_common.stack.k8s_client')
+    @mock.patch('mtp_common.stack.client')
     @mock.patch('mtp_common.stack.load_incluster_config')
     def test_not_first_in_k8s(self, mock_config, mock_client):
         self.setup_k8s_responses(mock_config, mock_client, pod_name='api-234')
         self.assertFalse(is_first_instance())
 
-    @mock.patch('mtp_common.stack.k8s_client')
+    @mock.patch('mtp_common.stack.client')
     @mock.patch('mtp_common.stack.load_incluster_config')
     def test_not_first_in_k8s_because_terminating(self, mock_config, mock_client):
         self.setup_k8s_responses(mock_config, mock_client, pod_name='api-345')
         self.assertFalse(is_first_instance())
 
-    @mock.patch('mtp_common.stack.k8s_client')
+    @mock.patch('mtp_common.stack.client')
     @mock.patch('mtp_common.stack.load_incluster_config')
     def test_not_in_k8s(self, mock_config, mock_client):
         self.setup_k8s_responses(mock_config, mock_client, pod_name='api-123')
@@ -60,10 +60,24 @@ class StackTestCase(SimpleTestCase):
             is_first_instance()
         mock_client.assert_not_called()
 
-    @mock.patch('mtp_common.stack.k8s_client')
+    @mock.patch('mtp_common.stack.client')
     @mock.patch('mtp_common.stack.load_incluster_config')
     def test_forbidden_in_k8s(self, mock_config, mock_client):
         self.setup_k8s_responses(mock_config, mock_client, pod_name='api-123')
         mock_client.CoreV1Api().list_namespaced_pod.side_effect = ApiException(status=403)
         with self.assertRaises(StackInterrogationException):
             is_first_instance()
+
+    @mock.patch('mtp_common.stack.client')
+    @mock.patch('mtp_common.stack.load_incluster_config')
+    def test_get_current_pod(self, mock_config, mock_client):
+        self.setup_k8s_responses(mock_config, mock_client, pod_name='api-123')
+        pod = get_current_pod()
+        self.assertEqual(pod.status.phase, 'Running')
+
+    @mock.patch('mtp_common.stack.client')
+    @mock.patch('mtp_common.stack.load_incluster_config')
+    def test_not_found_current_pod(self, mock_config, mock_client):
+        self.setup_k8s_responses(mock_config, mock_client, pod_name='api-456')
+        pod = get_current_pod()
+        self.assertIsNone(pod)

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -3,67 +3,12 @@ from unittest import mock
 
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException
-import responses
 
-from mtp_common.stack import InstanceNotInAsgException, StackInterrogationException, is_first_instance
+from mtp_common.stack import StackInterrogationException, is_first_instance
 from tests.utils import SimpleTestCase
 
 
 class StackTestCase(SimpleTestCase):
-    def setup_aws_responses(self, rsps, mock_boto3, instance_id, asg_name):
-        os.environ.pop('KUBERNETES_SERVICE_HOST', None)
-        rsps.add(rsps.GET, 'http://169.254.169.254/latest/dynamic/instance-identity/document',
-                 json={'instanceId': instance_id, 'region': 'eu-west-1'})
-        mock_autoscaling_client = mock_boto3.client()
-        autoscaling_instances = []
-        if asg_name:
-            autoscaling_instances.append({'AutoScalingGroupName': asg_name})
-        mock_autoscaling_client.describe_auto_scaling_instances.return_value = {
-            'AutoScalingInstances': autoscaling_instances
-        }
-        mock_autoscaling_client.describe_auto_scaling_groups.return_value = {
-            'AutoScalingGroups': [{'Instances': [
-                {'InstanceId': 'i-91234567890123456', 'LifecycleState': 'InService'},  # not first
-                {'InstanceId': 'i-01234567890123456', 'LifecycleState': 'InService'},  # first
-                {'InstanceId': 'i-00234567890123456', 'LifecycleState': 'Terminating'},  # not counted
-            ]}]
-        }
-
-    @mock.patch('mtp_common.stack.boto3')
-    def test_first_in_asg(self, mock_boto3):
-        with responses.RequestsMock() as rsps:
-            self.setup_aws_responses(rsps, mock_boto3, 'i-01234567890123456', 'test-asg')
-            self.assertTrue(is_first_instance())
-
-    @mock.patch('mtp_common.stack.boto3')
-    def test_not_first_in_asg(self, mock_boto3):
-        with responses.RequestsMock() as rsps:
-            self.setup_aws_responses(rsps, mock_boto3, 'i-91234567890123456', 'test-asg')
-            self.assertFalse(is_first_instance())
-
-    @mock.patch('mtp_common.stack.boto3')
-    def test_not_first_in_asg_because_terminating(self, mock_boto3):
-        with responses.RequestsMock() as rsps:
-            self.setup_aws_responses(rsps, mock_boto3, 'i-00234567890123456', 'test-asg')
-            self.assertFalse(is_first_instance())
-
-    @mock.patch('mtp_common.stack.boto3')
-    def test_not_in_asg(self, mock_boto3):
-        with responses.RequestsMock() as rsps:
-            self.setup_aws_responses(rsps, mock_boto3, 'i-00004567890123456', None)
-            with self.assertRaises(InstanceNotInAsgException):
-                is_first_instance()
-
-    @mock.patch('mtp_common.stack.boto3')
-    def test_not_in_aws(self, mock_boto3):
-        with responses.RequestsMock() as rsps:
-            rsps.add(rsps.GET, 'http://169.254.169.254/latest/dynamic/instance-identity/document',
-                     status=404)
-            mock_autoscaling_client = mock_boto3.client()
-            with self.assertRaises(StackInterrogationException):
-                is_first_instance()
-        mock_autoscaling_client.assert_not_called()
-
     def setup_k8s_responses(self, mock_config, mock_client, pod_name):
         from kubernetes.client.configuration import Configuration
 


### PR DESCRIPTION
this will be used to add `get_current_pod().status.pod_ip` to all app's `ALLOWED_HOSTS` so that prometheus' service monitors would be able to access them. they cannot be configured with custom request headers