### PR TITLE
Update sentry libs

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -33,6 +33,7 @@ def setup_django_for_testing(_: Context):
     settings.configure(
         APP='common',
         ENVIRONMENT='test',
+        APP_GIT_COMMIT='0000000',
         DEBUG=True,
         SECRET_KEY='a' * 24,
         ROOT_URLCONF='tests.urls',

--- a/mtp_common/templates/mtp_common/sentry-js.html
+++ b/mtp_common/templates/mtp_common/sentry-js.html
@@ -1,10 +1,13 @@
 {% if sentry_dsn %}
-  <script src="https://cdn.ravenjs.com/3.24.1/raven.min.js" crossorigin="anonymous"></script>
+  <script src="https://browser.sentry-cdn.com/5.11.2/bundle.min.js" integrity="sha384-FLzYisBa7tvsi/ZP1ISnzZJqBkmw5mvwk7KOmH82W9wdPZKG3bG9hSO8GQFVSlOu" crossorigin="anonymous"></script>
   <script>
-    if (Raven) {
-      Raven.config('{{ sentry_dsn }}', {
+    if (Sentry) {
+      Sentry.init({
+        dsn: '{{ sentry_dsn }}',
+        release: '{{ APP_GIT_COMMIT|default:'unknown' }}',
+        environment: '{{ ENVIRONMENT }}',
         whitelistUrls: [/app\.bundle\.js/]
-      }).install();
+      });
     }
   </script>
 {% endif %}

--- a/mtp_common/templatetags/mtp_common.py
+++ b/mtp_common/templatetags/mtp_common.py
@@ -141,7 +141,9 @@ def sentry_js():
     if sentry_client is not None:
         sentry_dsn = sentry_client.get_public_dsn('https') or None
     return {
-        'sentry_dsn': sentry_dsn
+        'sentry_dsn': sentry_dsn,
+        'ENVIRONMENT': settings.ENVIRONMENT,
+        'APP_GIT_COMMIT': settings.APP_GIT_COMMIT,
     }
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
 ]
 extras_require = {
     'monitoring': [
-        'raven>=6.6,<7',
+        'sentry-sdk>0.14,<0.15',
     ],
     'testing': [
         'flake8>=3.7,<4',

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -64,7 +64,7 @@ class TemplateTagTestCase(SimpleTestCase):
         response = self.load_mocked_template(template, {})
         html = response.content.decode('utf-8')
         self.assertIn(sentry_dsn, html)
-        self.assertIn('Raven.config', html)
+        self.assertIn('Sentry.init', html)
 
     def test_page_list(self):
         template = """


### PR DESCRIPTION
to prepare for move to sentry.io rather than MoJ-hosted version