### PR TITLE
Fix link focus outline on Chrome

### DIFF
--- a/mtp_common/assets-src/stylesheets/_base.scss
+++ b/mtp_common/assets-src/stylesheets/_base.scss
@@ -1,4 +1,8 @@
 // GOV.UK Overrides
+a:focus {
+  outline-offset: 0;
+}
+
 strong {
   font-weight: bold;
 }

--- a/setup.py
+++ b/setup.py
@@ -16,11 +16,11 @@ with open('README.rst') as readme:
     README = readme.read()
 
 install_requires = [
-    'Django>=1.11,<2',
+    'Django>=2.0,<2.1',
     'django-form-error-reporting>=0.7',
     'django-widget-tweaks>=1.4,<1.5',
     'django-zendesk-tickets>=0.12',
-    'pytz>=2018.9',
+    'pytz>=2019.1',
     'requests>=2.18,<3',
     'requests-oauthlib>=1,<2',
     'slumber>=0.7,<0.8',

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ install_requires = [
     'govuk-bank-holidays>=0.3',
     'cryptography>=2.3,<3',
     'PyJWT>=1.7,<2',
-    'kubernetes>=9,<10',  # corresponds to server version 1.13
+    'kubernetes>=11,<12',  # corresponds to server version 1.15
     'prometheus_client>=0.6,<1',
 ]
 extras_require = {


### PR DESCRIPTION
[MTP-1514](https://dsdmoj.atlassian.net/browse/MTP-1514)

Chrome appears to have a new default outline offset which has pushed the focus box outwards on links that are focused.

```css
// user agent style sheet
a:-webkit-any-link:focus {
    outline-offset: 1px;
}
```

Example:

![outline-offset](https://user-images.githubusercontent.com/911238/89033761-70f13100-d32f-11ea-8705-f1e01ba8501a.png)

This does not happen in the latest Firefox or Safari

---

also:

- update kubernetes client to more closely match cloud platform
- use a single consistent version requirement for Django in all apps c.f. [MTP-1519](https://dsdmoj.atlassian.net/browse/MTP-1519)