### PR TITLE
Added PYTHONUNBUFFERED and normalised container naming conventions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - db
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DJANGO_SETTINGS_MODULE: mtp_api.settings.base
       DEBUG: "True"
@@ -45,7 +46,7 @@ services:
       START_PAGE_URL: http://start-page:8005
     command: '/app/docker-entrypoint.sh'
   noms-ops:
-    container_name: mtp_noms-ops
+    container_name: mtp_noms_ops
     build:
       context: ../money-to-prisoners-noms-ops
       dockerfile: $PWD/Dockerfile-dev
@@ -63,6 +64,7 @@ services:
       - api
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DJANGO_SETTINGS_MODULE: mtp_noms_ops.settings.base
       DEBUG: "True"
@@ -73,7 +75,7 @@ services:
       PUBLIC_SEND_MONEY_HOST: http://send-money:8004
       START_PAGE_URL: http://start-page:8005
   send-money:
-    container_name: mtp_send-money
+    container_name: mtp_send_money
     build:
       context: ../money-to-prisoners-send-money
       dockerfile: $PWD/Dockerfile-dev
@@ -83,6 +85,7 @@ services:
         LOCAL_DJANGO_SETTINGS_MODULE: mtp_send_money.settings.base
     ports:
       - "8004:8004"
+      - "3004:3004"
     volumes:
       - ../money-to-prisoners-send-money:/app
       - send-money_node_modules:/app/node_modules
@@ -90,6 +93,7 @@ services:
       - api
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DJANGO_SETTINGS_MODULE: mtp_send_money.settings.base
       DEBUG: "True"
@@ -118,6 +122,7 @@ services:
       - api
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DJANGO_SETTINGS_MODULE: mtp_cashbook.settings.base
       DEBUG: "True"
@@ -128,7 +133,7 @@ services:
       PUBLIC_SEND_MONEY_HOST: http://send-money:8004
       START_PAGE_URL: http://start-page:8005
   bank-admin:
-    container_name: mtp_bank-admin
+    container_name: mtp_bank_admin
     build:
       context: ../money-to-prisoners-bank-admin
       dockerfile: $PWD/Dockerfile-dev
@@ -146,6 +151,7 @@ services:
       - api
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DJANGO_SETTINGS_MODULE: mtp_bank_admin.settings.base
       DEBUG: "True"
@@ -156,7 +162,7 @@ services:
       PUBLIC_SEND_MONEY_HOST: http://send-money:8004
       START_PAGE_URL: http://start-page:8005
   start-page:
-    container_name: mtp_start-page
+    container_name: mtp_start_page
     build:
       context: ../money-to-prisoners-start-page
       dockerfile: Dockerfile-dev
@@ -169,6 +175,7 @@ services:
       - send-money
     user: mtp
     environment:
+      PYTHONUNBUFFERED: 1
       ENV: local
       DEBUG: "True"
   # transaction-uploader:
@@ -181,6 +188,7 @@ services:
         # SERVICE: transaction-uploader
     # user: mtp
     # environment:
+      # PYTHONUNBUFFERED: 1
       # ENV: local
       # DEBUG: "True"
       # API_URL: http://api:8000


### PR DESCRIPTION
The reason for adding PYTHONUNBUFFERED is that setting this environment variable to a non-null value prevents python from caching STDOUT/STDERR, which can be confusing as with docker compose this cached output will be emitted on container restart, which can add complexity when trying establish when an error is thrown