### PR TITLE
Added a fix to allow the functional tests to be run in docker, where chromeDriver cannot be sandboxed

### DIFF
--- a/mtp_common/test_utils/webdrivers.py
+++ b/mtp_common/test_utils/webdrivers.py
@@ -33,7 +33,7 @@ class ChromeConf:
         if not os.path.exists(self.executable_path):
             self.download_binary()
         options = webdriver.ChromeOptions()
-        if os.geteuid() == 0:
+        if os.geteuid() == 0 or os.path.exists('/.dockerenv'):
             options.add_argument('no-sandbox')
         options.add_argument('window-size=%d,%d' % (width, height))
         if headless:


### PR DESCRIPTION
See https://stackoverflow.com/questions/59087200/google-chrome-failed-to-move-to-new-namespace