### PR TITLE
Enable python dependency resolution

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -15,6 +15,7 @@ RUN curl 'https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-fo
 
 # avoid trashing venv
 RUN cp -r --preserve=ownership /app/venv /venv
+RUN sed -i 's:/app/venv:/venv:g' /venv/bin/[!_]**
 
 COPY --chown=mtp:mtp . /app/
 #This should already be the case but just to be sure...
@@ -29,6 +30,6 @@ USER mtp
 # For more info: https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN python /app/run.py build
-CMD ["python", "/app/run.py", "serve"]
+RUN /venv/bin/python /app/run.py build
+CMD ["/venv/bin/python", "/app/run.py", "serve"]
 # vim: ft=dockerfile

--- a/build_tasks.py
+++ b/build_tasks.py
@@ -116,7 +116,7 @@ def python_dependencies(context: Context, extras=None):
         requirements = install_requires.copy()
         if extras:
             requirements.extend(extras_require[extras])
-    return context.pip_command('install', *requirements)
+    return context.pip_command('install', '--use-feature=2020-resolver', *requirements)
 
 
 @tasks.register('python_dependencies', 'govuk_template', 'compile_messages', 'precompile_python_code', default=True)
@@ -183,7 +183,7 @@ def docs(context: Context):
     try:
         from sphinx.application import Sphinx
     except ImportError:
-        context.pip_command('install', 'Sphinx')
+        context.pip_command('install', '--use-feature=2020-resolver', 'Sphinx')
         from sphinx.application import Sphinx
 
     context.shell('cp', 'README.rst', 'docs/README.rst')

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (10, 0, 0)
+VERSION = (10, 0, 1)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/mtp_common/build_tasks/tasks.py
+++ b/mtp_common/build_tasks/tasks.py
@@ -38,7 +38,7 @@ def serve(context: Context, port=8000, browsersync_port=3000, browsersync_ui_por
     try:
         from watchdog.observers import Observer
     except ImportError:
-        context.pip_command('install', 'watchdog>0.8,<0.9')
+        context.pip_command('install', '--use-feature=2020-resolver', 'watchdog>0.8,<0.9')
         from watchdog.observers import Observer
 
     from watchdog.events import PatternMatchingEventHandler
@@ -132,10 +132,10 @@ def python_dependencies(context: Context, common_path=None):
     """
     Updates python dependencies
     """
-    context.pip_command('install', '-r', context.requirements_file)
+    context.pip_command('install', '--use-feature=2020-resolver', '-r', context.requirements_file)
     if common_path:
         context.pip_command('uninstall', '--yes', 'money-to-prisoners-common')
-        context.pip_command('install', '--force-reinstall', '-e', common_path)
+        context.pip_command('install', '--use-feature=2020-resolver', '--force-reinstall', '-e', common_path)
         context.shell('rm', '-rf', 'webpack.config.js')  # because it refers to path to common
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Enabling shiny new pip dependency resolution (which we should start using at some point anyway) to work around an issue revolving around an erroneous implicit specification of the version of the python `Django` library now we specify it in this library alone and not in the money-to-prisoners services (in the name of reducing dependency complexity/duplication)