### PR TITLE
MTP-1511 Account for case of running run.py build installed with old money-to-prisoners-common against new dependencies

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -30,6 +30,13 @@ USER mtp
 # For more info: https://pythonspeed.com/articles/activate-virtualenv-dockerfile/
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# This is necessary as a seperate explicit command because we want to account for the case where we need to upgrade money-to-prisoners-common to
+# the version specified in the requirements before running run.py build
+# as run.py build may fail with import errors if it's being run against the old money-to-prisoners-common that is installed againt the new code
+# This came about when upgreding django, but may happen with other major dependency upgrades too
+# TODO Fix this in a nicer way
+RUN /venv/bin/pip install --upgrade pip
+RUN /venv/bin/pip install -r /app/requirements/dev.txt
 RUN /venv/bin/python /app/run.py build
 CMD ["/venv/bin/python", "/app/run.py", "serve"]
 # vim: ft=dockerfile


### PR DESCRIPTION
This is necessary as a separate explicit command because we want to account for the case where we need to upgrade money-to-prisoners-common to the version specified in the requirements before running run.py build as run.py build may fail with import errors if it's being run against the old money-to-prisoners-common that is installed against the new code

 This came about when upgrading django, but may happen with other major dependency upgrades too