### PR TITLE
Fix run.py test command

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -116,7 +116,7 @@ def python_dependencies(context: Context, extras=None):
         requirements = install_requires.copy()
         if extras:
             requirements.extend(extras_require[extras])
-    return context.pip_command('install', '--use-feature=2020-resolver', *requirements)
+    return context.pip_command('install', *requirements)
 
 
 @tasks.register('python_dependencies', 'govuk_template', 'compile_messages', 'precompile_python_code', default=True)
@@ -183,7 +183,7 @@ def docs(context: Context):
     try:
         from sphinx.application import Sphinx
     except ImportError:
-        context.pip_command('install', '--use-feature=2020-resolver', 'Sphinx')
+        context.pip_command('install', 'Sphinx')
         from sphinx.application import Sphinx
 
     context.shell('cp', 'README.rst', 'docs/README.rst')

--- a/mtp_common/build_tasks/tasks.py
+++ b/mtp_common/build_tasks/tasks.py
@@ -38,7 +38,7 @@ def serve(context: Context, port=8000, browsersync_port=3000, browsersync_ui_por
     try:
         from watchdog.observers import Observer
     except ImportError:
-        context.pip_command('install', '--use-feature=2020-resolver', 'watchdog>0.8,<0.9')
+        context.pip_command('install', 'watchdog>0.8,<0.9')
         from watchdog.observers import Observer
 
     from watchdog.events import PatternMatchingEventHandler
@@ -132,10 +132,10 @@ def python_dependencies(context: Context, common_path=None):
     """
     Updates python dependencies
     """
-    context.pip_command('install', '--use-feature=2020-resolver', '-r', context.requirements_file)
+    context.pip_command('install', '-r', context.requirements_file)
     if common_path:
         context.pip_command('uninstall', '--yes', 'money-to-prisoners-common')
-        context.pip_command('install', '--use-feature=2020-resolver', '--force-reinstall', '-e', common_path)
+        context.pip_command('install', '--force-reinstall', '-e', common_path)
         context.shell('rm', '-rf', 'webpack.config.js')  # because it refers to path to common
 
 

--- a/mtp_common/build_tasks/tasks.py
+++ b/mtp_common/build_tasks/tasks.py
@@ -114,7 +114,7 @@ def test(context: Context, test_labels=None, functional_tests=False, accessibili
     if webdriver:
         os.environ['WEBDRIVER'] = webdriver
     test_labels = (test_labels or '').split()
-    return context.management_command('test', args=test_labels, interactive=False)
+    return context.management_command('test', *test_labels, interactive=False)
 
 
 @tasks.register(hidden=True)


### PR DESCRIPTION
Django's `call_command` was failing probably because it now takes arguments in a different way.

Also, pip now raises a warning about the 2020 resolver flag not having any effect.