### PR TITLE
Simpler python dependency tree

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,11 +21,10 @@ Features
 Usage
 -----
 
-Add ``money-to-prisoners-common==<version>`` to the Money to Prisoners application’s requirements.txt.
-There are two variations as setuptools *extras*:
-
-* Use ``money-to-prisoners-common[testing]==<version>`` for environments requiring testing
-* Use ``money-to-prisoners-common[monitoring]==<version>`` for the deployed version
+Add ``money-to-prisoners-common==<version>`` to the Money to Prisoners application’s requirements base.txt.
+There is an additional variant installed as a setuptools *extra*:
+Use ``money-to-prisoners-common[testing]==<version>`` for environments requiring testing; this is placed into
+the application’s requirements dev.txt.
 
 Add url patterns:
 

--- a/run.py
+++ b/run.py
@@ -5,9 +5,6 @@ import sys
 from mtp_common.build_tasks.executor import Executor
 import build_tasks  # noqa
 
-if sys.version_info[0:2] < (3, 5):
-    raise SystemExit('python 3.5+ is required')
-
 
 def main():
     exit(Executor(root_path=os.path.dirname(__file__)).run())
@@ -19,4 +16,7 @@ def test():
 
 
 if __name__ == '__main__':
+    if sys.version_info[0:2] < (3, 6):
+        raise SystemExit('Python 3.6+ is required')
+
     main()

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,9 @@ install_requires = [
     'PyJWT>=1.7,<2',
     'kubernetes>=11,<12',  # corresponds to server version 1.15
     'prometheus_client>=0.6,<1',
+    'sentry_sdk==0.16.5',
 ]
 extras_require = {
-    'monitoring': [
-        'sentry_sdk==0.16.5',
-    ],
     'testing': [
         'flake8>=3.7,<4',
         'pep8-naming>=0.8.2,<1',


### PR DESCRIPTION
Simplify python dependency tree by removing [monitoring] extra from mtp-common. This allows all client apps to install the correct version of mtp-common on _first run_ (i.e. when none are installed) and without having to decide which extras it requires in the current environment.

---

Problem
-------

On first run (every run in CI and first run when developing locally), there is no mtp-common installed.
Currently it arbitrarily installed the _latest_ version.
This often means the build process then needs to re-install different versions of various packages.
This sometimes leads to import errors or incorrectly loaded libraries.
Locally, simply re-running the build script solves the issue, but in CI this is not possible

![1](https://user-images.githubusercontent.com/911238/104754867-a230b280-5751-11eb-8bd4-b3b1d8f55042.png)

Solution
--------

Allow all client apps to easily install their base set of requirements.
This is done by subsuming packages for production/docker environments into the base requirements.
This means that on first run, client apps can simply install their base requirements
thereby getting all necessary packages with correct versions.

![2](https://user-images.githubusercontent.com/911238/104755367-3e5ab980-5752-11eb-87dc-6369aca0fcfe.png)
