### PR TITLE
nomis: Retry twice for nomis.get_* requests

### DIFF
--- a/mtp_common/nomis.py
+++ b/mtp_common/nomis.py
@@ -285,7 +285,7 @@ def convert_date_param(param):
     return None
 
 
-def get_account_balances(prison_id, prisoner_number, retries=0, session=None):
+def get_account_balances(prison_id, prisoner_number, retries=2, session=None):
     return connector.get(
         '/prison/{prison_id}/offenders/{prisoner_number}/accounts'.format(
             prison_id=quote_plus(prison_id),
@@ -297,7 +297,7 @@ def get_account_balances(prison_id, prisoner_number, retries=0, session=None):
 
 
 def get_transaction_history(prison_id, prisoner_number, account_code,
-                            from_date, to_date=None, retries=0, session=None):
+                            from_date, to_date=None, retries=2, session=None):
     params = {
         'from_date': convert_date_param(from_date),
         'to_date': convert_date_param(to_date),
@@ -335,7 +335,7 @@ def create_transaction(prison_id, prisoner_number, amount, record_id,
     )
 
 
-def get_photograph_data(prisoner_number, retries=0, session=None):
+def get_photograph_data(prisoner_number, retries=2, session=None):
     result = connector.get(
         '/offenders/{prisoner_number}/image'.format(
             prisoner_number=quote_plus(prisoner_number)
@@ -347,7 +347,7 @@ def get_photograph_data(prisoner_number, retries=0, session=None):
     return result.get('image', None)
 
 
-def get_location(prisoner_number, retries=0, session=None):
+def get_location(prisoner_number, retries=2, session=None):
     result = connector.get(
         '/offenders/{prisoner_number}/location'.format(
             prisoner_number=quote_plus(prisoner_number)

--- a/mtp_common/nomis.py
+++ b/mtp_common/nomis.py
@@ -335,7 +335,7 @@ def create_transaction(prison_id, prisoner_number, amount, record_id,
     )
 
 
-def get_photograph_data(prisoner_number, retries=2, session=None):
+def get_photograph_data(prisoner_number, retries=0, session=None):
     result = connector.get(
         '/offenders/{prisoner_number}/image'.format(
             prisoner_number=quote_plus(prisoner_number)


### PR DESCRIPTION
Some of the requests to NOMIS API are timing out despite the timeout being
15s (which is high).

The `retries` parameter for the following functions now defaults to `2`:
- `nomis.get_account_balances()`
- `nomis.get_transaction_history()`
- ~`nomis.get_photograph_data()`~
- `nomis.get_location()`

Hopefully this may help with some of the requests failing.

**NOTE**: There may be other places where HTTP requests are made and these
may still timeout but this is a first step and it should be relatively
safe.

Ticket: https://dsdmoj.atlassian.net/browse/MTP-1768