### PR TITLE
Allow releasing to PyPI using Github actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install -U setuptools pip wheel
-            pip install .
-            python run.py python_dependencies --extras testing
+            pip install --editable .[testing]
       - save_cache:
           key: py-v1-{{ checksum "setup.py" }}
           paths:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release to PYPI
+on:
+  release:
+    types: [created]
+jobs:
+  release:
+    name: Release to PYPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Setup nodejs
+        uses: actions/setup-node@v2
+        with:
+          node-version: 10
+      - name: Install os dependencies
+        run: sudo apt-get install gettext
+        # TODO: anything else??
+      - name: Install python dependencies
+        run: |
+          pip install -U setuptools pip wheel
+          pip install .[testing]
+      - name: Build and upload to PYPI
+        run: python run.py upload
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install -U setuptools pip wheel
-          pip install .[testing]
+          pip install --editable .[testing]
       - name: Build and upload to PYPI
         run: python run.py upload
         env:

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Developing
 * Test using ``./run.py test`` or ``python setup.py test``
 * Update the version with ``./run.py set_version --version [?.?.?]``
 * Commit and push changes to github
-* Submit to PyPi with ``./run.py upload``
+* Submit to PyPi with by making a new release on github (or ``./run.py upload`` locally if necessary)
 
 Translating
 -----------

--- a/build_tasks.py
+++ b/build_tasks.py
@@ -197,7 +197,8 @@ def upload(context: Context):
     """
     Builds and uploads MTP-common to pypi
     """
-    return context.shell(sys.executable, 'setup.py', 'sdist', 'bdist_wheel', 'upload')
+    context.shell(sys.executable, 'setup.py', 'sdist', 'bdist_wheel')
+    context.shell('twine', 'upload', '--non-interactive', 'dist/*')
 
 
 @tasks.register()

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (11, 0, 0)
+VERSION = (11, 1, '0rc1')
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "11.0.0",
+  "version": "11.1.0-rc.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ extras_require = {
         'flake8-blind-except~=0.1.1',
         'flake8-debugger~=4.0',
         'responses~=0.12.0',
+        'twine~=3.3.0',
     ],
 }
 


### PR DESCRIPTION
… using twine (previously used an outdated mechanism to upload to PyPI).
There's a new Github action which is called when a release is made in Github.
It builds and packages mtp-common then uploads to PyPI.

[MTP-1539](https://dsdmoj.atlassian.net/browse/MTP-1539)