### PR TITLE
Increased default verbosity of build_tasks

### DIFF
--- a/mtp_common/build_tasks/executor.py
+++ b/mtp_common/build_tasks/executor.py
@@ -346,7 +346,7 @@ class Context:
                  colour: bool = True,
                  django_settings: str = '',
                  requirements_file: str = 'requirements/dev.txt',
-                 verbosity: Parameter.constraint_from_choices(int, (0, 1, 2)) = 1):
+                 verbosity: Parameter.constraint_from_choices(int, (0, 1, 2)) = 2):
         self.app = app
 
         self.print_task_names = print_task_names

--- a/mtp_common/build_tasks/executor.py
+++ b/mtp_common/build_tasks/executor.py
@@ -342,7 +342,8 @@ class Context:
     """
 
     def __init__(self, app: App,
-                 print_task_names: bool = False,
+                 print_task_names: bool = True,
+                 print_task_paths: bool = True,
                  colour: bool = True,
                  django_settings: str = '',
                  requirements_file: str = 'requirements/dev.txt',
@@ -350,6 +351,7 @@ class Context:
         self.app = app
 
         self.print_task_names = print_task_names
+        self.print_task_paths = print_task_paths
         self.verbosity = verbosity
         self.use_colour = colour and supports_color()
 
@@ -559,8 +561,15 @@ class Executor:
                 print_parameter(printer, parameter)
 
     def run_task(self, context, task):
-        if context.print_task_names and task.name != 'help':
-            context.info(context.blue_style(f'\n> Running {task.name} task...'))
+        if task.name != 'help':
+            if context.print_task_names:
+                context.info(context.blue_style(f'\n> Running {task.name} task...'))
+            if context.print_task_paths:
+                path = inspect.getfile(task.func)
+                line = inspect.getsourcelines(task.func)[1]
+
+                context.info(context.blue_style(f'File "{path}", line {line}'))
+
         os.chdir(self.root_path)
         context.overidden_tasks = self.available_tasks.get_overidden_tasks(task.name)
         return task(context)


### PR DESCRIPTION
* Increased default verbosity was 1 (normal), increased to 2 (verbose).
* Show task name by default (`show_task_names`)
* Show task path/line number by default (`show_task_paths`, new)

Example:

![Screenshot](https://user-images.githubusercontent.com/238563/107238775-1e03df00-6a20-11eb-8421-5df29e30baf8.png)





Ticket: https://dsdmoj.atlassian.net/browse/MTP-1797