### PR TITLE
docker-compose: Added `FIU_EMAIL` env to cashbook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
       DJANGO_SETTINGS_MODULE: mtp_cashbook.settings.base
       DEBUG: "True"
       API_URL: http://api:8000
+      FIU_EMAIL: fiu-example@example.com
       PUBLIC_CASHBOOK_HOST: http://cashbook:8001
       PUBLIC_BANK_ADMIN_HOST: http://bank-admin:8002
       PUBLIC_NOMS_OPS_HOST: http://noms-ops:8003


### PR DESCRIPTION
This is just a minor tweak so that when using docker-compose Cashbook FAQ
page shows some email address instead of awkard empty space.

**NOTE**: Related to [this other `cashbook` PR](https://github.com/ministryofjustice/money-to-prisoners-cashbook/pull/539).

Part of ticket: https://dsdmoj.atlassian.net/browse/MTP-1833