### PR TITLE
Added 'account requests' banner as per Justin prototype

### DIFF
--- a/mtp_common/templates/mtp_common/user_admin/account-requests-banner.html
+++ b/mtp_common/templates/mtp_common/user_admin/account-requests-banner.html
@@ -1,0 +1,27 @@
+{% load i18n %}
+{% load mtp_common %}
+
+
+{% if user_request_count > 0 %}
+    {% url 'list-users' as link %}
+    {% captureoutput as manage_requests %}
+        <a href="{{ link }}">
+            {% blocktrans count count=user_request_count %}
+            Manage request
+            {% plural %}
+            Manage requests
+            {% endblocktrans %}
+        </a>
+    {% endcaptureoutput %}
+
+    {% captureoutput as account_requests_heading %}
+        {% blocktrans trimmed count count=user_request_count %}
+            There is {{ count }} new account request
+        {% plural %}
+            There are {{ count }} new account requests
+        {% endblocktrans %}
+        {{ manage_requests }}.
+    {% endcaptureoutput %}
+
+    {% include 'mtp_common/components/notification-banner.html' with banner_level=_('Important') banner_title=_('Important') banner_heading=account_requests_heading only %}
+{% endif %}


### PR DESCRIPTION
Prototype for MTP-1818 (https://pm-intelligence-tool.herokuapp.com/)
has a banner which is similar to the one in `cashbook` but adds a link to
manage these requests.

This makes sense and we should use the same banner for both `cashbook`
and `noms-ops` so it makes sense to move this into `mtp-common` and
re-use in both places.

MTP-1818: https://dsdmoj.atlassian.net/browse/MTP-1818