### PR TITLE
Ability to use pdb/attach to docker-compose containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - db_data:/var/lib/postgresql/data
   api:
     container_name: mtp_api
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-api
       dockerfile: $PWD/Dockerfile-dev
@@ -50,6 +52,8 @@ services:
     command: '/app/docker-entrypoint.sh'
   noms-ops:
     container_name: mtp_noms_ops
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-noms-ops
       dockerfile: $PWD/Dockerfile-dev
@@ -82,6 +86,8 @@ services:
       START_PAGE_URL: http://start-page:8005
   send-money:
     container_name: mtp_send_money
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-send-money
       dockerfile: $PWD/Dockerfile-dev
@@ -114,6 +120,8 @@ services:
       START_PAGE_URL: http://start-page:8005
   cashbook:
     container_name: mtp_cashbook
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-cashbook
       dockerfile: $PWD/Dockerfile-dev
@@ -147,6 +155,8 @@ services:
       START_PAGE_URL: http://start-page:8005
   bank-admin:
     container_name: mtp_bank_admin
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-bank-admin
       dockerfile: $PWD/Dockerfile-dev
@@ -179,6 +189,8 @@ services:
       START_PAGE_URL: http://start-page:8005
   start-page:
     container_name: mtp_start_page
+    stdin_open: true
+    tty: true
     build:
       context: ../money-to-prisoners-start-page
       dockerfile: Dockerfile-dev


### PR DESCRIPTION
Run `$ docker attach [container_name]` to attach to the running container.

This is useful to use debuggers like `pdb` in the running containers - without whatever is typed on the host doesn't seem to reach the containers.

See: https://stackoverflow.com/a/59717363