### PR TITLE
Share security check rejection reason categories between all apps

### DIFF
--- a/mtp_common/security/checks.py
+++ b/mtp_common/security/checks.py
@@ -1,0 +1,52 @@
+import logging
+
+from django.utils.translation import gettext_lazy as _
+
+logger = logging.getLogger('mtp')
+
+# rejection reason categories where the stored value is user-specified text
+# NB: you cannot remove keys as they will have been persisted in the database,
+#     instead remove fields from the form in noms-ops as necessary
+CHECK_REJECTION_TEXT_CATEGORY_LABELS = {
+    'fiu_investigation_id': _('Associated FIU investigation'),
+    'intelligence_report_id': _('Associated intelligence report (IR)'),
+    'other_reason': _('Other reason'),
+}
+# rejection reason categories where the stored value is simply `True`
+# NB: you cannot remove keys as they will have been persisted in the database,
+#     instead remove fields from the form in noms-ops as necessary
+CHECK_REJECTION_BOOL_CATEGORY_LABELS = {
+    'payment_source_paying_multiple_prisoners': _('Payment source is paying multiple prisoners'),
+    'payment_source_multiple_cards': _('Payment source is using multiple cards'),
+    'payment_source_linked_other_prisoners': _('Payment source is linked to other prisoner/s'),
+    'payment_source_known_email': _('Payment source is using a known email'),
+    'payment_source_unidentified': _('Payment source is unidentified'),
+    'prisoner_multiple_payments_payment_sources': _('Prisoner has multiple payments or payment sources'),
+}
+
+# all known security check rejection reason categories
+CHECK_REJECTION_CATEGORIES = (
+    frozenset(CHECK_REJECTION_TEXT_CATEGORY_LABELS) | frozenset(CHECK_REJECTION_BOOL_CATEGORY_LABELS)
+)
+
+
+def human_readable_check_rejection_reasons(rejection_reasons: dict) -> list:
+    """
+    Turns the DB representation of a security check's rejection reasons into a list of human-readable descriptions
+    """
+    descriptions = []
+    if not rejection_reasons:
+        # in case None is persisted in older records
+        return descriptions
+    for key, value in rejection_reasons.items():
+        if key in CHECK_REJECTION_TEXT_CATEGORY_LABELS:
+            descriptions.append(f'{CHECK_REJECTION_TEXT_CATEGORY_LABELS[key]}: {value}')
+        elif key in CHECK_REJECTION_BOOL_CATEGORY_LABELS:
+            if value:
+                descriptions.append(f'{CHECK_REJECTION_BOOL_CATEGORY_LABELS[key]}')
+            if value is not True:
+                logger.error('Security check rejection bool category is not True')
+        else:
+            logger.error('Security check has unknown rejection category')
+            descriptions.append(f'{key}: {value}')
+    return descriptions

--- a/tests/test_security_checks.py
+++ b/tests/test_security_checks.py
@@ -1,0 +1,43 @@
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from mtp_common.security.checks import human_readable_check_rejection_reasons
+
+
+class SecurityCheckRejectionReasonCategories(SimpleTestCase):
+    def test_empty_rejection_reasons(self):
+        self.assertListEqual(human_readable_check_rejection_reasons(None), [])
+        self.assertListEqual(human_readable_check_rejection_reasons({}), [])
+
+    def test_text_rejection_reason_category(self):
+        self.assertListEqual(human_readable_check_rejection_reasons({
+            'intelligence_report_id': 'ABC321',
+        }), [
+            'Associated intelligence report (IR): ABC321'
+        ])
+
+    def test_bool_rejection_reason_category(self):
+        self.assertListEqual(human_readable_check_rejection_reasons({
+            'payment_source_unidentified': True,
+        }), [
+            'Payment source is unidentified'
+        ])
+
+    @mock.patch('mtp_common.security.checks.logger')
+    def test_malformed_bool_rejection_reason_category(self, mocked_logger):
+        self.assertListEqual(human_readable_check_rejection_reasons({
+            'payment_source_unidentified': 'False name used',
+        }), [
+            'Payment source is unidentified'
+        ])
+        mocked_logger.error.assert_called()
+
+    @mock.patch('mtp_common.security.checks.logger')
+    def test_malformed_rejection_reason_category(self, mocked_logger):
+        self.assertListEqual(human_readable_check_rejection_reasons({
+            'mercury_code': 'ABC321',
+        }), [
+            'mercury_code: ABC321'
+        ])
+        mocked_logger.error.assert_called()


### PR DESCRIPTION
…so that they can be displayed in a [form in noms-ops](https://github.com/ministryofjustice/money-to-prisoners-noms-ops/blob/9bef4c46667dd7dd1b63355682539a861fb0917d/mtp_noms_ops/apps/security/forms/check.py#L183) and [exported in human-readable form in api](https://github.com/ministryofjustice/money-to-prisoners-api/blob/fdf74298284804779e95294cf418ce97e5ea8666/mtp_api/apps/core/management/commands/dump_for_ap.py#L73) using the same standard labels.