### PR TITLE
docker-compose: Improvement to using mtp-common in editable modified

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,9 @@ services:
       - api_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
-    # command: /venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common serve
+    # command: >
+    #   bash -c "/venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common
+    #   && /venv/bin/python /app/run.py serve"
     links:
       - db
     user: mtp
@@ -69,7 +71,9 @@ services:
       - noms-ops_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
-    # command: /venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common serve
+    # command: >
+    #   bash -c "/venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common
+    #   && /venv/bin/python /app/run.py serve"
     links:
       - api
     user: mtp
@@ -103,7 +107,9 @@ services:
       - send-money_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
-    # command: /venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common serve
+    # command: >
+    #   bash -c "/venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common
+    #   && /venv/bin/python /app/run.py serve"
     links:
       - api
     user: mtp
@@ -137,7 +143,9 @@ services:
       - cashbook_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
-    # command: /venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common serve
+    # command: >
+    #   bash -c "/venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common
+    #   && /venv/bin/python /app/run.py serve"
     links:
       - api
     user: mtp
@@ -172,7 +180,9 @@ services:
       - bank-admin_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
-    # command: /venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common serve
+    # command: >
+    #   bash -c "/venv/bin/python /app/run.py python_dependencies --common-path ../money-to-prisoners-common
+    #   && /venv/bin/python /app/run.py serve"
     links:
       - api
     user: mtp


### PR DESCRIPTION
Configuring docker-compose to use local, editable, `mtp-common` has some
issues which are caused by the fact we're installing a new version of
`mtp-common` but then carry on within the same process which may still
point to old version/paths.

This may cause some assets to not be found.

I'm experimenting with the idea of splitting the `python_dependencies`
task from the `serve` task so that the serving of the application happens
after `mtp-common` is fully replaced (and in a new process).

See:
- https://github.com/ministryofjustice/money-to-prisoners-common/pull/420/files
- https://www.edureka.co/community/21344/how-do-i-execute-multiple-commands-using-docker-compose