### PR TITLE
Ensure ELK logging formatter can serialise any object passed to the log message

### DIFF
--- a/mtp_common/logging.py
+++ b/mtp_common/logging.py
@@ -34,4 +34,4 @@ class ELKFormatter(logging.Formatter):
             # ensure that any data passed can be json-serialised
             log.update(record.elk_fields)
 
-        return json.dumps(log)
+        return json.dumps(log, default=str, ensure_ascii=False)


### PR DESCRIPTION
For instance, the regular logging formatter will happily accept `logging.info('Model saved %s', model_instance)` because it uses string formatting to render the log message. The `ELKFormatter` now attaches all arguments passed to log messages so needs to be able to turn them into JSON.