### PR TITLE
Drop support for Python < 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Setup nodejs
         uses: actions/setup-node@v2
         with:

--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,7 @@ If you run into issues with the dockeriesd development environment, the followin
 
 * Shutdown existing docker-compose containers, and remove volumes/networks/images with ``docker-compose down -v --rmi all`` from money-to-prisoners-common root directory (note this will wipe your local database, omit the ``-v`` to prevent this)
 * Pull fresh base images via ``./manage.py config docker-login && ./manage.py image pull-ecr`` from from money-to-prisoners-deploy root directory
-* Rebuild the service images without cache via ``docker-compose --no-cache build`` from money-to-prisoners-common root directory
+* Rebuild the service images without cache via ``docker-compose build --no-cache`` from money-to-prisoners-common root directory
 * Restart the services in the background via ``docker-compose up -d`` from money-to-prisoners-common root directory,
 * Tail the logs at your leisure via ``docker-compose logs <service_name>`` from money-to-prisoners-common root directory, where ``<service_name>`` is an optional argument corresponding to a ``services`` key in the ``docker-compose.yml`` (e.g. api, noms-ops etc)
 

--- a/run.py
+++ b/run.py
@@ -17,7 +17,7 @@ def test():
 
 
 if __name__ == '__main__':
-    if sys.version_info[0:2] < (3, 6):
-        raise SystemExit('Python 3.6+ is required')
+    if sys.version_info[0:2] < (3, 8):
+        raise SystemExit('Python 3.8+ is required')
 
     main()

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ import sys
 
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 6):
-    raise SystemError('Python version must be at least 3.6')
+if sys.version_info < (3, 8):
+    raise SystemError('Python version must be at least 3.8')
 
 # allow setup.py to be run from any path
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
@@ -72,7 +72,7 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
We're upgrading base images to Ubuntu 20.04 which comes with Python 3.8
so it makes sense to drop support for anything older and also run the
CI tests on Python 3.8.

PS: Also fixed `docker-compose build` command in README.

Ticket: https://dsdmoj.atlassian.net/secure/RapidBoard.jspa?rapidView=79&projectKey=MTP&modal=detail&selectedIssue=MTP-1841