### PR TITLE
Add wrapper utility for accessing S3 bucket

### DIFF
--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -65,7 +65,11 @@ class S3BucketClient:
     ):
         if isinstance(file_contents, bytes):
             file_contents = io.BytesIO(file_contents)
-        tags = dict(tags or {}, app=settings.APP, environment=settings.ENVIRONMENT)
+        tags = tags or {}
+        tags.update({
+            'application': settings.APP,
+            'environment-name': settings.ENVIRONMENT,
+        })
         extra_args = {'Tagging': urlencode(tags)}
         if content_type:
             extra_args['ContentType'] = content_type

--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -5,7 +5,9 @@ from urllib.parse import urlencode
 
 import boto3
 from django.conf import settings
+from django.core.signing import base64_hmac
 from django.http.response import StreamingHttpResponse
+from django.utils.crypto import constant_time_compare, get_random_string
 from kubernetes import client as k8s_client
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException, load_incluster_config
@@ -95,3 +97,41 @@ class S3BucketClient:
         )
         response['Last-Modified'] = s3_object['ResponseMetadata']['HTTPHeaders']['last-modified']
         return response
+
+
+def _sign_bucket_path(bucket_path: str) -> str:
+    return base64_hmac(salt='mtp_common.s3_bucket', value=bucket_path, key=settings.S3_BUCKET_SIGNING_KEY)
+
+
+def make_download_token(path_prefix: str, filename: str) -> dict:
+    """
+    Given a path prefix and file name, generates a longer path to store objects in S3
+    and also returns a signed token to be used for downloads.
+    The signed token reveals the full S3 path, however the signature prevents tampering.
+    """
+    if not path_prefix or not filename:
+        raise ValueError
+    path_prefix = path_prefix.strip('/') + '/' + get_random_string(35)
+    bucket_path = f'{path_prefix}/{filename}'
+    signature = _sign_bucket_path(bucket_path)
+    download_token = f'{path_prefix}/{signature}/{filename}'
+    return {
+        'bucket_path': bucket_path,
+        'download_token': download_token,
+    }
+
+
+def parse_download_token(download_token: str) -> str:
+    """
+    Parses a download token and returns a full path to the object in S3 if the token has a valid signature.
+    :raises ValueError if the token is invalid
+    """
+    download_token = download_token.rsplit('/', 2)
+    if len(download_token) != 3:
+        raise ValueError
+    path_prefix, signature, filename = download_token
+    bucket_path = f'{path_prefix}/{filename}'
+    expected_signature = _sign_bucket_path(bucket_path)
+    if not constant_time_compare(signature, expected_signature):
+        raise ValueError
+    return bucket_path

--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -102,17 +102,20 @@ class S3BucketClient:
         return response
 
 
-def make_bucket_download_url(path_prefix: str, filename: str) -> dict:
+def generate_upload_path(path_prefix: str, filename: str) -> str:
     """
-    Given a path prefix and file name, generates a longer path to store objects in S3
+    Given a path prefix and file name, generates a longer path to store files in S3
     in order to make bucket paths not guessable/enumerable.
-    The download url links directly to the mtp-emails app.
     """
+    path_prefix = path_prefix.strip('/')
+    filename = filename.lstrip('/')
     if not path_prefix or not filename:
         raise ValueError
-    path_prefix = path_prefix.strip('/') + '/' + get_random_string(35)
-    bucket_path = f'{path_prefix}/{filename}'
-    return {
-        'bucket_path': bucket_path,
-        'download_url': urljoin(settings.EMAILS_URL, f'/download/{bucket_path}'),
-    }
+    return f'{path_prefix}/{get_random_string(35)}/{filename}'
+
+
+def get_download_url(bucket_path) -> str:
+    """
+    Returns absolute url to download file from S3 via mtp-emails app.
+    """
+    return urljoin(settings.EMAILS_URL, f'/download/{bucket_path}')

--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -85,7 +85,7 @@ class S3BucketClient:
         )
         return file_contents.getvalue()
 
-    def download_stream(self, path: str) -> StreamingHttpResponse:
+    def download_as_streaming_response(self, path: str) -> StreamingHttpResponse:
         s3_object = self.s3_client.get_object(
             Bucket=self.s3_secret['bucket_name'],
             Key=path,

--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -1,7 +1,7 @@
 import base64
 import io
 import typing
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urljoin
 
 import boto3
 from django.conf import settings
@@ -106,8 +106,9 @@ def _sign_bucket_path(bucket_path: str) -> str:
 def make_download_token(path_prefix: str, filename: str) -> dict:
     """
     Given a path prefix and file name, generates a longer path to store objects in S3
-    and also returns a signed token to be used for downloads.
+    and also returns a signed token to be used for downloads and a pre-composed download url.
     The signed token reveals the full S3 path, however the signature prevents tampering.
+    The download url links directly to the mtp-emails app.
     """
     if not path_prefix or not filename:
         raise ValueError
@@ -118,6 +119,7 @@ def make_download_token(path_prefix: str, filename: str) -> dict:
     return {
         'bucket_path': bucket_path,
         'download_token': download_token,
+        'download_url': urljoin(settings.EMAILS_URL, f'/download/{download_token}'),
     }
 
 

--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -1,0 +1,72 @@
+import base64
+import io
+import typing
+
+import boto3
+from django.conf import settings
+from kubernetes import client as k8s_client
+from kubernetes.client.rest import ApiException
+from kubernetes.config import ConfigException, load_incluster_config
+
+
+class S3BucketError(Exception):
+    pass
+
+
+class S3BucketClient:
+    """
+    Utility to access S3 bucket shared between MTP apps within one environment
+    The primary use is to store files generated asynchronously for later download, e.g. via a link in an email
+    """
+
+    def __init__(self):
+        # load config from inside k8s cluster
+        try:
+            load_incluster_config()
+        except ConfigException as e:
+            raise S3BucketError('Not running inside Kubernetes cluster', e)
+
+        # load k8s secret from app's namespace which contains S3 bucket name and associated IAM access token
+        try:
+            secret = k8s_client.CoreV1Api().read_namespaced_secret(
+                name='s3',
+                namespace=f'money-to-prisoners-{settings.ENVIRONMENT}',
+            )
+            self.s3_secret = {
+                key: base64.b64decode(value).decode()
+                for key, value in secret.data.items()
+            }
+        except ApiException as e:
+            raise S3BucketError('S3 secret not found', e)
+
+        # check contents
+        if any(
+            key not in self.s3_secret
+            for key in ('access_key_id', 'secret_access_key', 'bucket_name')
+        ):
+            raise S3BucketError('S3 secret is missing required keys')
+
+        # create authenticated connection to S3
+        self.s3_client = boto3.client(
+            's3',
+            aws_access_key_id=self.s3_secret['access_key_id'],
+            aws_secret_access_key=self.s3_secret['secret_access_key'],
+        )
+
+    def upload(self, file_contents: typing.Union[bytes, io.RawIOBase, io.BufferedIOBase], path: str):
+        if isinstance(file_contents, bytes):
+            file_contents = io.BytesIO(file_contents)
+        self.s3_client.upload_fileobj(
+            Fileobj=file_contents,
+            Bucket=self.s3_secret['bucket_name'],
+            Key=path,
+        )
+
+    def dowload(self, path: str) -> bytes:
+        file_contents = io.BytesIO()
+        self.s3_client.download_fileobj(
+            Bucket=self.s3_secret['bucket_name'],
+            Key=path,
+            Fileobj=file_contents,
+        )
+        return file_contents.getvalue()

--- a/mtp_common/tasks.py
+++ b/mtp_common/tasks.py
@@ -4,6 +4,7 @@ import typing
 from notifications_python_client.errors import APIError, InvalidResponse
 
 from mtp_common.notify import NotifyClient
+from mtp_common.s3_bucket import S3BucketClient
 from mtp_common.spooling import Context, spoolable
 
 logger = logging.getLogger('mtp')
@@ -55,3 +56,17 @@ def send_email(
             )
         else:
             raise e
+
+
+@spoolable(body_params=('file_contents',))
+def upload_to_s3(file_contents: bytes, path: str, content_type: str = None, tags: dict = None):
+    """
+    Asynchronously uploads a file into shared S3 bucket
+    """
+    client = S3BucketClient()
+    client.upload(
+        file_contents=file_contents,
+        path=path,
+        content_type=content_type,
+        tags=tags,
+    )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
     'transifex-client>=0.14,<0.15',
     'cryptography~=3.4',
     'PyJWT~=2.1.0',
+    'boto3~=1.18.32',
     'kubernetes>=17,<19',  # corresponds to server version 1.17 or 1.18
     'prometheus_client>=0.6,<1',
     'sentry-sdk~=1.3.0',

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -135,7 +135,7 @@ class S3BucketTestCase(SimpleTestCase):
             self.assertEqual(body_bytes.decode(), '1,2,3\n')
 
 
-@override_settings(S3_BUCKET_SIGNING_KEY='0000111122223333')
+@override_settings(S3_BUCKET_SIGNING_KEY='0000111122223333', EMAILS_URL='http://localhost:8006')
 class DownloadTokenTestCase(SimpleTestCase):
     def test_token_round_trip(self):
         tokens = make_download_token('backup/2021-09-02', 'files.zip')
@@ -143,6 +143,8 @@ class DownloadTokenTestCase(SimpleTestCase):
                             msg='full bucket path should have some random characters added')
         self.assertGreater(len(tokens['download_token']), len(tokens['bucket_path']),
                            msg='download token should contain a signature')
+        self.assertTrue(tokens['download_url'].startswith('http://localhost:8006/download/'))
+        self.assertTrue(tokens['download_url'].endswith(tokens['download_token']))
         bucket_path = parse_download_token(tokens['download_token'])
         self.assertEqual(bucket_path, tokens['bucket_path'],
                          msg='parsed download token should be the full bucket path')

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -123,7 +123,7 @@ class S3BucketTestCase(SimpleTestCase):
                 'Body': io.BytesIO('1,2,3\n'.encode()),
                 'ContentType': 'text/csv',
             }
-            response = client.download_stream('test.csv')
+            response = client.download_as_streaming_response('test.csv')
             header_bytes = bytes(response)
             body_bytes = b''.join(iter(response))
             self.assertEqual(mock_s3_client.get_object.call_count, 1)

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -1,0 +1,77 @@
+import io
+import os
+from unittest import mock
+
+from kubernetes.client.rest import ApiException
+from kubernetes.config.incluster_config import SERVICE_HOST_ENV_NAME
+
+from mtp_common.s3_bucket import S3BucketClient, S3BucketError
+from tests.utils import SimpleTestCase
+
+
+def mock_s3_secret_response(mock_client, valid_response=True):
+    secret = mock.MagicMock()
+    if valid_response:
+        data = {
+            'bucket_arn': 'YXJuOmF3czpzMzo6OmNsb3VkLXBsYXRmb3JtLVRFU1Qx', 'bucket_name': 'Y2xvdWQtcGxhdGZvcm0tVEVTVDE=',
+            'access_key_id': 'QUtJQTAwMDAwMDAwMDA=', 'secret_access_key': 'MDAwMDAwMDAwMDAwMDAwMDAwMDA=',
+        }
+    else:
+        data = {}
+    secret.data = data
+    mock_client.CoreV1Api().read_namespaced_secret.return_value = secret
+
+
+class S3BucketTestCase(SimpleTestCase):
+    @mock.patch.dict(os.environ, {SERVICE_HOST_ENV_NAME: ''})
+    def test_outside_cluster(self):
+        with self.assertRaises(S3BucketError) as e:
+            S3BucketClient()
+        self.assertIn('Not running inside Kubernetes cluster', str(e.exception))
+
+    @mock.patch('mtp_common.s3_bucket.k8s_client')
+    @mock.patch('mtp_common.s3_bucket.load_incluster_config')
+    def test_cannot_find_secret(self, mock_config, mock_client):
+        self.setup_k8s_incluster_config(mock_config, pod_name='app')
+        mock_client.CoreV1Api().read_namespaced_secret.side_effect = ApiException(status=404)
+        with self.assertRaises(S3BucketError) as e:
+            S3BucketClient()
+        self.assertIn('S3 secret not found', str(e.exception))
+
+    @mock.patch('mtp_common.s3_bucket.k8s_client')
+    @mock.patch('mtp_common.s3_bucket.load_incluster_config')
+    def test_malformed_secret(self, mock_config, mock_client):
+        self.setup_k8s_incluster_config(mock_config, pod_name='app')
+        mock_s3_secret_response(mock_client, valid_response=False)
+        with self.assertRaises(S3BucketError) as e:
+            S3BucketClient()
+        self.assertIn('S3 secret is missing required keys', str(e.exception))
+
+    @mock.patch('mtp_common.s3_bucket.k8s_client')
+    @mock.patch('mtp_common.s3_bucket.load_incluster_config')
+    def test_upload_passes_params_to_boto(self, mock_config, mock_client):
+        self.setup_k8s_incluster_config(mock_config, pod_name='app')
+        mock_s3_secret_response(mock_client)
+        client = S3BucketClient()
+        with mock.patch.object(client, 's3_client') as mock_s3_client:
+            client.upload(b'00000', 'test.bin')
+            self.assertEqual(mock_s3_client.upload_fileobj.call_count, 1)
+            kwargs = mock_s3_client.upload_fileobj.call_args_list[0].kwargs
+            self.assertEqual(kwargs['Bucket'], 'cloud-platform-TEST1')
+            self.assertEqual(kwargs['Key'], 'test.bin')
+            self.assertTrue(isinstance(kwargs['Fileobj'], io.BytesIO))
+
+    @mock.patch('mtp_common.s3_bucket.k8s_client')
+    @mock.patch('mtp_common.s3_bucket.load_incluster_config')
+    def test_download_passes_params_to_boto(self, mock_config, mock_client):
+        self.setup_k8s_incluster_config(mock_config, pod_name='app')
+        mock_s3_secret_response(mock_client)
+        client = S3BucketClient()
+        with mock.patch.object(client, 's3_client') as mock_s3_client:
+            mock_s3_client.download_fileobj.side_effect = lambda **kw: kw['Fileobj'].write(b'12345')
+            data = client.dowload('test.bin')
+            self.assertEqual(mock_s3_client.download_fileobj.call_count, 1)
+            kwargs = mock_s3_client.download_fileobj.call_args_list[0].kwargs
+            self.assertEqual(data, b'12345')
+            self.assertEqual(kwargs['Bucket'], 'cloud-platform-TEST1')
+            self.assertEqual(kwargs['Key'], 'test.bin')

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -63,7 +63,7 @@ class S3BucketTestCase(SimpleTestCase):
             self.assertEqual(kwargs['Key'], 'test.bin')
             self.assertDictEqual(
                 dict(parse_qsl(kwargs['ExtraArgs']['Tagging'])),
-                {'app': 'common', 'environment': 'test'},
+                {'application': 'common', 'environment-name': 'test'},
             )
             self.assertNotIn('ContentType', kwargs['ExtraArgs'])
             self.assertTrue(isinstance(kwargs['Fileobj'], io.BytesIO))
@@ -79,8 +79,8 @@ class S3BucketTestCase(SimpleTestCase):
             self.assertEqual(mock_s3_client.upload_fileobj.call_count, 1)
             kwargs = mock_s3_client.upload_fileobj.call_args_list[0].kwargs
             tags = dict(parse_qsl(kwargs['ExtraArgs']['Tagging']))
-            tags.pop('app')
-            tags.pop('environment')
+            tags.pop('application')
+            tags.pop('environment-name')
             self.assertDictEqual(tags, {'abc': '123', 'key': 'value'})
 
     @mock.patch('mtp_common.s3_bucket.k8s_client')

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,7 +1,5 @@
-import os
 from unittest import mock
 
-from kubernetes.client.configuration import Configuration
 from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException
 
@@ -11,14 +9,7 @@ from tests.utils import SimpleTestCase
 
 class StackTestCase(SimpleTestCase):
     def setup_k8s_responses(self, mock_config, mock_client, pod_name):
-        os.environ['KUBERNETES_SERVICE_HOST'] = '127.0.0.1'
-        os.environ['KUBERNETES_SERVICE_PORT'] = '9988'
-        os.environ['POD_NAME'] = pod_name
-        configuration = Configuration()
-        configuration.host = 'http://127.0.0.1:9988'
-        configuration.api_key = {'authorization': 'bearer T0ken'}
-        Configuration.set_default(configuration)
-        mock_config.return_value = None
+        self.setup_k8s_incluster_config(mock_config, pod_name)
         pod1 = mock.MagicMock()
         pod1.metadata.name = 'api-123'
         pod1.status.phase = 'Running'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,10 @@
+import os
 from unittest import mock
 
 from django.test import SimpleTestCase as DjangoSimpleTestCase
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
+from kubernetes.client.configuration import Configuration
 
 from mtp_common.analytics import AnalyticsPolicy
 
@@ -14,6 +16,17 @@ class SimpleTestCase(DjangoSimpleTestCase):
         mocked_template.return_value = template
         mocked_context.return_value = context
         return self.client.get(reverse('dummy'), **extra)
+
+    @classmethod
+    def setup_k8s_incluster_config(cls, mock_config, pod_name):
+        os.environ['KUBERNETES_SERVICE_HOST'] = '127.0.0.1'
+        os.environ['KUBERNETES_SERVICE_PORT'] = '9988'
+        os.environ['POD_NAME'] = pod_name
+        configuration = Configuration()
+        configuration.host = 'http://127.0.0.1:9988'
+        configuration.api_key = {'authorization': 'bearer T0ken'}
+        Configuration.set_default(configuration)
+        mock_config.return_value = None
 
 
 class TestAcceptingCookiePolicyMiddleware(MiddlewareMixin):


### PR DESCRIPTION
…which is shared amongst MTP apps in an environment. This utility
• automatically finds the appropriate bucket via a kubernetes secret
• can upload a file (setting tags and content type)
• can download a file directly into `bytes`
• can stream a download into an HTTP response
• generates urls for use in file downloads via new `emails` app (with random string to prevent enumeration and guessing of links)