### PR TITLE
Restrict download links from S3 to be only from under the `emails/*`

### DIFF
--- a/mtp_common/s3_bucket.py
+++ b/mtp_common/s3_bucket.py
@@ -114,8 +114,11 @@ def generate_upload_path(path_prefix: str, filename: str) -> str:
     return f'{path_prefix}/{get_random_string(35)}/{filename}'
 
 
-def get_download_url(bucket_path) -> str:
+def get_download_url(bucket_path: str) -> str:
     """
     Returns absolute url to download file from S3 via mtp-emails app.
+    :raises ValueError if the object is not under emails/*
     """
+    if not bucket_path.startswith('emails/'):
+        raise ValueError('Only files within emails/* are downloadable via emails app')
     return urljoin(settings.EMAILS_URL, f'/download/{bucket_path}')

--- a/tests/test_s3_bucket.py
+++ b/tests/test_s3_bucket.py
@@ -137,22 +137,32 @@ class S3BucketTestCase(SimpleTestCase):
 
 @override_settings(EMAILS_URL='http://localhost:8006')
 class S3BucketDownloadURLTestCase(SimpleTestCase):
-    def test_make_download_url(self):
-        bucket_path = generate_upload_path('backup-folder/2021', '09-06.zip')
-        self.assertTrue(bucket_path.startswith('backup-folder/2021'),
+    def test_make_upload_path_and_download_url(self):
+        bucket_path = generate_upload_path('emails/2021', '09-06.zip')
+        self.assertTrue(bucket_path.startswith('emails/2021'),
                         msg='bucket path should preserve folder structure')
         self.assertTrue(bucket_path.endswith('/09-06.zip'),
                         msg='bucket path should preserve filename')
-        self.assertGreater(len(bucket_path), len('backup-folder/2021') + len('/09-06.zip'),
+        self.assertGreater(len(bucket_path), len('emails/2021') + len('/09-06.zip'),
                            msg='bucket path should have added randomness')
         download_url = get_download_url(bucket_path)
         self.assertTrue(download_url.startswith('http://localhost:8006/'))
         self.assertTrue(download_url.endswith(bucket_path))
 
-    def test_cannot_make_download_url_with_empty_inputs(self):
+    def test_cannot_make_upload_path_with_empty_inputs(self):
         with self.assertRaises(ValueError):
             generate_upload_path('', 'filename.csv')
         with self.assertRaises(ValueError):
             generate_upload_path('/', 'filename.csv')
         with self.assertRaises(ValueError):
             generate_upload_path('folder/abc/', '')
+
+    def test_cannot_get_download_url_outside_of_emails_folder(self):
+        samples = (
+            '',
+            'names.csv',
+            'backup/names.csv',
+        )
+        for sample in samples:
+            with self.assertRaises(ValueError):
+                get_download_url(sample)


### PR DESCRIPTION
… path such that bucket lifecycle applies and the downloadable files are logically name-spaced