### PR TITLE
Collect request duration metrics for Prometheus

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -79,6 +79,7 @@ def setup_django_for_testing(_: Context):
             },
         }],
         MIDDLEWARE=(
+            'mtp_common.metrics.middleware.RequestMetricsMiddleware',
             'django.contrib.sessions.middleware.SessionMiddleware',
             'django.middleware.locale.LocaleMiddleware',
             'django.middleware.common.CommonMiddleware',

--- a/mtp_common/metrics/middleware.py
+++ b/mtp_common/metrics/middleware.py
@@ -1,0 +1,38 @@
+import os
+from time import perf_counter
+
+from django.apps import apps
+from prometheus_client import Histogram
+
+request_duration = Histogram(
+    'mtp_django_request_duration', 'Django HTTP request durations',
+    labelnames=('view', 'method', 'status', 'pid'),
+    buckets=(0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 25.0, 50.0, float('inf'))
+)
+try:
+    app = apps.get_app_config('metrics')
+    app.register_collector(request_duration)
+except LookupError:
+    pass
+
+
+class RequestMetricsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.metrics_request_started = perf_counter()
+
+        response = self.get_response(request)
+
+        if hasattr(request, 'metrics_request_started'):
+            view_name = getattr(getattr(request, 'resolver_match', None), 'view_name', None) or '<unnamed view>'
+            duration = perf_counter() - request.metrics_request_started
+            request_duration.labels(
+                view=view_name,
+                method=request.method,
+                status=str(response.status_code),
+                pid=str(os.getpid()),  # pid is needed as uwsgi runs with multiple workers
+            ).observe(duration)
+
+        return response

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,8 +1,9 @@
+import re
 from unittest import mock
 
-from django.test import RequestFactory, override_settings
+from django.test import override_settings
+from django.urls import reverse
 
-from mtp_common.metrics.views import metrics_view
 from tests.utils import SimpleTestCase
 
 
@@ -10,7 +11,19 @@ from tests.utils import SimpleTestCase
 @override_settings(METRICS_USER='???', METRICS_PASS='???')
 class MetricsTestCase(SimpleTestCase):
     def test_app_info_metrics(self):
-        request = RequestFactory().get('/metrics/')
-        response = metrics_view(request)
-        self.assertContains(response, 'app="common"')
-        self.assertContains(response, 'environment="test"')
+        response = self.client.get(reverse('prometheus_metrics'))
+        content = response.content.decode()
+        matches = re.search('^mtp_app_info{([^}]+)}', content, flags=re.MULTILINE)
+        app_info = matches.group(1)
+        self.assertIn('app="common"', app_info)
+        self.assertIn('environment="test"', app_info)
+
+    def test_request_duration_metrics(self):
+        self.client.get(reverse('dummy'))  # ensure dummy view was called at least once
+        response = self.client.get(reverse('prometheus_metrics'))
+        content = response.content.decode()
+        self.assertTrue(any(
+            'view="dummy"' in line
+            for line in content.splitlines()
+            if line.startswith('mtp_django_request_duration_count')
+        ))

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,7 @@ from django.urls import reverse_lazy
 
 from mtp_common.auth import views
 from mtp_common.auth.basic import basic_auth
+from mtp_common.metrics.views import metrics_view
 from mtp_common.user_admin.forms import SignUpForm
 import mtp_common.user_admin.views as user_admin_views
 from mtp_common.views import SettingsView
@@ -88,5 +89,8 @@ urlpatterns = [
     ),
 
     # mocked basic auth view
-    url(r'^basic-auth/', basic_auth('BASIC_USER', 'BASIC_PASSWORD')(dummy_view), name='basic-auth')
+    url(r'^basic-auth/', basic_auth('BASIC_USER', 'BASIC_PASSWORD')(dummy_view), name='basic-auth'),
+
+    # prometheus metrics
+    url(r'^metrics.txt$', metrics_view, name='prometheus_metrics'),
 ]


### PR DESCRIPTION
By adding this _optional_ middleware, MTP apps can record the time HTTP requests take for collection by Prometheus (and therefore viewing in Grafana or alerting with Alertmanager)