### PR TITLE
Increase default timeouts from 15 to 30s

### DIFF
--- a/mtp_common/auth/api_client.py
+++ b/mtp_common/auth/api_client.py
@@ -76,8 +76,7 @@ class MoJOAuth2Session(LocalisedOAuth2Session):
     def request(self, method, url, data=None, headers=None, **kwargs):
         if self.base_url and not urlsplit(url).scheme:
             url = urljoin(self.base_url, url)
-        if 'timeout' not in kwargs:
-            kwargs['timeout'] = 15
+        kwargs.setdefault('timeout', 30)
         return super().request(method, url, data=data, headers=headers, **kwargs)
 
 
@@ -104,7 +103,7 @@ def authenticate(username, password):
         username=username,
         password=password,
         auth=HTTPBasicAuth(settings.API_CLIENT_ID, settings.API_CLIENT_SECRET),
-        timeout=15,
+        timeout=30,
         encoding='utf-8'
     )
 
@@ -128,7 +127,7 @@ def revoke_token(access_token):
             'client_id': settings.API_CLIENT_ID,
             'client_secret': settings.API_CLIENT_SECRET,
         },
-        timeout=15
+        timeout=30
     )
     return response.status_code == 200
 
@@ -174,7 +173,7 @@ def get_authenticated_api_session(username, password):
         username=username,
         password=password,
         auth=HTTPBasicAuth(settings.API_CLIENT_ID, settings.API_CLIENT_SECRET),
-        timeout=15,
+        timeout=30,
         encoding='utf-8'
     )
     return session

--- a/mtp_common/nomis.py
+++ b/mtp_common/nomis.py
@@ -165,7 +165,7 @@ class Connector:
             'Authorization': f'Bearer {bearer_token}',
         }
 
-    def request(self, verb, path, params=None, json=None, timeout=15, retries=0, session=None):
+    def request(self, verb, path, params=None, json=None, timeout=30, retries=0, session=None):
         """
         Makes a request call to Prison API (i.e. NOMIS).
         You probably want to use the `get` or the `post` methods instead.
@@ -193,7 +193,7 @@ class Connector:
             'status_code': response.status_code,
         }
 
-    def get(self, path, params=None, timeout=15, retries=0, session=None):
+    def get(self, path, params=None, timeout=30, retries=0, session=None):
         """
         Makes a GET request to Prison API (i.e. NOMIS).
         """
@@ -205,7 +205,7 @@ class Connector:
             }
         return self.request('get', path, params=params, timeout=timeout, retries=retries, session=session)
 
-    def post(self, path, data=None, timeout=15, retries=0, session=None):
+    def post(self, path, data=None, timeout=30, retries=0, session=None):
         """
         Makes a POST request to Prison API (i.e. NOMIS).
         """
@@ -234,7 +234,7 @@ class Connector:
                 'Content-Length': '0',
                 'Authorization': f'Basic {creds}',
             },
-            timeout=10,
+            timeout=30,
         )
         response.raise_for_status()
 


### PR DESCRIPTION
…for requests to mtp-api, hmpps-auth and prison-api