### PR TITLE
Add missing methods to faked MoJ user models to match Django models more closely

### DIFF
--- a/mtp_common/auth/models.py
+++ b/mtp_common/auth/models.py
@@ -39,6 +39,9 @@ class MojUser:
     def username(self):
         return self.user_data.get('username')
 
+    def get_username(self):
+        return self.username
+
     @property
     def email(self):
         return self.user_data.get('email')
@@ -59,6 +62,9 @@ class MojUser:
             ]
             self._full_name = ' '.join(filter(None, name_parts))
         return self._full_name
+
+    def get_short_name(self):
+        return self.user_data.get('first_name')
 
     def get_initials(self):
         if self.get_full_name():
@@ -88,7 +94,13 @@ class MojAnonymousUser:
     last_name = ''
     email = ''
 
+    def get_username(self):
+        return self.username
+
     def get_full_name(self):
+        return ''
+
+    def get_short_name(self):
         return ''
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,29 +1,31 @@
 from django.test import SimpleTestCase
 
-from mtp_common.auth.models import MojUser
+from mtp_common.auth.models import MojUser, MojAnonymousUser
 from mtp_common.auth.test_utils import generate_tokens
 
 
 class UserPermissionsTestCase(SimpleTestCase):
-
-    def setUp(self, *args, **kwargs):
-        super().setUp(*args, **kwargs)
-
+    def setUp(self):
         self.user = MojUser(5, generate_tokens(), {
+            'pk': 5,
+            'username': 'sam-hall',
             'first_name': 'Sam',
             'last_name': 'Hall',
+            'email': 'sam@mtp.local',
             'permissions': [
                 'allowed_permission_1',
                 'allowed_permission_2',
                 'allowed_permission_3'
-            ]
+            ],
         })
 
     def test_fields(self):
+        self.assertEqual(self.user.get_username(), 'sam-hall')
         self.assertEqual(self.user.first_name, 'Sam')
         self.assertEqual(self.user.last_name, 'Hall')
         self.assertEqual(self.user.get_full_name(), 'Sam Hall')
-        self.assertFalse(self.user.email)
+        self.assertEqual(self.user.get_short_name(), 'Sam')
+        self.assertEqual(self.user.email, 'sam@mtp.local')
 
     def test_has_perm_succeeds_if_present(self):
         self.assertTrue(self.user.has_perm('allowed_permission_1'))
@@ -55,3 +57,19 @@ class UserPermissionsTestCase(SimpleTestCase):
             'allowed_permission_1',
             'forbidden_permission'
         ]))
+
+
+class AnonymousUserPermissionsTestCase(SimpleTestCase):
+    def setUp(self):
+        self.user = MojAnonymousUser()
+
+    def test_fields(self):
+        self.assertEqual(self.user.get_username(), '')
+        self.assertEqual(self.user.first_name, '')
+        self.assertEqual(self.user.last_name, '')
+        self.assertEqual(self.user.get_full_name(), '')
+        self.assertEqual(self.user.get_short_name(), '')
+        self.assertEqual(self.user.email, '')
+
+    def test_has_no_perms(self):
+        self.assertFalse(self.user.has_perm('change_something'))


### PR DESCRIPTION
This is needed to fix a problem where `opencensus-ext-django` tries to call the `get_username` method on `request.user` which can be `MojAnonymousUser` or `MojUser` in mtp client apps.