### PR TITLE
MTP-1937: Initial support for GA4

### DIFF
--- a/mtp_common/analytics.py
+++ b/mtp_common/analytics.py
@@ -16,9 +16,13 @@ class AnalyticsPolicy:
     cookie_name = 'cookie_policy'
 
     def __init__(self, request):
-        self.google_analytics_id = getattr(settings, 'GOOGLE_ANALYTICS_ID', None)
         analytics_required = getattr(settings, 'ANALYTICS_REQUIRED', True)
+
+        self.google_analytics_id = getattr(settings, 'GOOGLE_ANALYTICS_ID', None)
+        self.ga4_measurement_id = getattr(settings, 'GA4_MEASUREMENT_ID', None)
+
         self.enabled = self.google_analytics_id and (analytics_required or self.is_cookie_policy_accepted(request))
+        self.ga4_enabled = self.ga4_measurement_id and (analytics_required or self.is_cookie_policy_accepted(request))
 
     def is_cookie_policy_accepted(self, request):
         """

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -9,6 +9,7 @@
 
 export var Analytics = {
   attrName: 'analytics',
+  ga4EventName: 'mtp_event',
 
   init: function () {
     if (this._gaExists()) {
@@ -38,6 +39,41 @@ export var Analytics = {
       }
       [].unshift.call(arguments, 'send');
       ga.apply(window, arguments);
+    }
+  },
+
+  /**
+   * Sends a custom GA4 'mtp_event' event with category/action/lavel params.
+   *
+   * NOTE: `category`/`action`/`label` need to be configured in
+   * Google Analytics under Admin > Custom definitions.
+   *
+   * Example
+   * ```JavaScript
+   * Analytics.ga4SendEvent('PrisonConfirmation', 'Confirm', eventLabel);
+   * ```
+   *
+   * @param {string} category Event category
+   * @param {string} action Event action
+   * @param {string} label Event label
+   */
+  ga4SendEvent: function (category, action, label) {
+    if (this._ga4Exists()) {
+      gtag.apply(window, 'event', this.ga4EventName, {
+        category: category || '',
+        action: action || '',
+        label: label || '',
+      });
+    }
+  },
+
+  /** Sends a GA4 'page_view' event with the give 'page_location'
+   *
+   * @param {string} pageLocation page location associated to the event
+   */
+  ga4SendPageView: function (pageLocation) {
+    if (this._ga4Exists()) {
+      gtag.apply(window, 'event', 'page_view', { 'page_location': pageLocation || '' });
     }
   },
 

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -37,11 +37,14 @@ export var Analytics = {
    */
   ga4SendEvent: function (category, action, label) {
     if (this._ga4Exists()) {
-      gtag.apply(window, 'event', this.ga4EventName, {
-        category: category || '',
-        action: action || '',
-        label: label || '',
-      });
+      gtag.apply(window, [
+        'event', this.ga4EventName,
+        {
+          category: category || '',
+          action: action || '',
+          label: label || '',
+        },
+      ]);
     }
   },
 
@@ -51,7 +54,7 @@ export var Analytics = {
    */
   ga4SendPageView: function (pageLocation) {
     if (this._ga4Exists()) {
-      gtag.apply(window, 'event', 'page_view', { 'page_location': pageLocation || '' });
+      gtag.apply(window, ['event', 'page_view', { 'page_location': pageLocation || '' }]);
     }
   },
 

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -58,7 +58,21 @@ export var Analytics = {
     return true;
   },
 
+  /**
+   * Returns true if GA's `ga()` (legacy) is available
+   *
+   * @returns {boolean} true if GA is available
+   */
   _gaExists: function () {
     return typeof ga === typeof Function;
-  }
+  },
+
+  /**
+   * Returns true if GA4's `gtag()` is available
+   *
+   * @returns {boolean} true if GA4 is available
+   */
+  _ga4Exists: function () {
+    return typeof gtag === typeof Function;
+  },
 };

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -4,7 +4,7 @@
 // - by adding the data-analytics attribute to any element that can be clicked
 //   eg <div data-analytics="pageview,/virtual/pageview/,user clicked there"/>
 // It needs the google analytics tracking code to be enabled on the page
-/* globals ga */
+/* globals ga gtag */
 'use strict';
 
 export var Analytics = {

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -20,31 +20,6 @@ export var Analytics = {
     }
   },
 
-  send: function () {
-    /*
-      Sends to GA passing through all specified arguments.
-      It appends an object with page, location and title to the call, if you don't want
-      this use rawSend instead.
-    */
-    if (this._gaExists()) {
-      var gaData = $('span.mtp-ga-data');
-      if (gaData) {
-        var page = gaData.data('page');
-        if (arguments[0] === 'pageview' && arguments.length > 1 && $.type(arguments[1]) === 'string') {
-          page = arguments[1];
-        }
-        var gaOverride = {
-          page: page,
-          location: gaData.data('location'),
-          title: gaData.data('title') || document.title
-        };
-        [].push.call(arguments, gaOverride);
-      }
-      [].unshift.call(arguments, 'send');
-      ga.apply(window, arguments);
-    }
-  },
-
   /**
    * Sends a custom GA4 'mtp_event' event with category/action/lavel params.
    *
@@ -80,6 +55,41 @@ export var Analytics = {
     }
   },
 
+  /**
+   * Sends a legacy GA custom event or `pageview` event
+   *
+   * @deprecated GA is deprecated in favour of GA4, use `ga4SendEvent()` or `ga4SendPageView()` instead
+   */
+  send: function () {
+    /*
+      Sends to GA passing through all specified arguments.
+      It appends an object with page, location and title to the call, if you don't want
+      this use rawSend instead.
+    */
+    if (this._gaExists()) {
+      var gaData = $('span.mtp-ga-data');
+      if (gaData) {
+        var page = gaData.data('page');
+        if (arguments[0] === 'pageview' && arguments.length > 1 && $.type(arguments[1]) === 'string') {
+          page = arguments[1];
+        }
+        var gaOverride = {
+          page: page,
+          location: gaData.data('location'),
+          title: gaData.data('title') || document.title
+        };
+        [].push.call(arguments, gaOverride);
+      }
+      [].unshift.call(arguments, 'send');
+      ga.apply(window, arguments);
+    }
+  },
+
+  /**
+   * Sends a legacy GA custom event or `pageview` event
+   *
+   * @deprecated GA is deprecated in favour of GA4, use `ga4SendEvent()` or `ga4SendPageView()` instead
+   */
   rawSend: function () {
     /*
       Sends to GA passing through all specified arguments.

--- a/mtp_common/assets-src/mtp_common/components/autocomplete-select/index.js
+++ b/mtp_common/assets-src/mtp_common/components/autocomplete-select/index.js
@@ -104,13 +104,17 @@ export var AutocompleteSelect = {
           $suggestion.click(function (e) {
             e.preventDefault();
             if ($hiddenInput.data('event-category')) {
+              var eventCategory = $hiddenInput.data('event-category');
+              var eventAction = 'Autocomplete';
+              var eventLabel = $visualInput.val() + ' > ' + suggestion.name;
               Analytics.send(
                 'event', {
-                  eventCategory: $hiddenInput.data('event-category'),
-                  eventAction: 'Autocomplete',
-                  eventLabel: $visualInput.val() + ' > ' + suggestion.name
+                  eventCategory: eventCategory,
+                  eventAction: eventAction,
+                  eventLabel: eventLabel,
                 }
               );
+              Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
             }
 
             $visualInput.val(suggestion.name);

--- a/mtp_common/assets-src/mtp_common/components/before-unload/index.js
+++ b/mtp_common/assets-src/mtp_common/components/before-unload/index.js
@@ -26,7 +26,9 @@ export var BeforeUnload = {
 
       $(window).on('beforeunload', function () {
         if ($form.serialize() !== initialData && !submitting) {
-          Analytics.send('pageview', '/-leaving_page_dialog/');
+          var pageLocation = '/-leaving_page_dialog/';
+          Analytics.send('pageview', pageLocation);
+          Analytics.ga4SendPageView(pageLocation);
           return message;
         }
       });

--- a/mtp_common/assets-src/mtp_common/components/print-analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/print-analytics/index.js
@@ -11,6 +11,7 @@ export var PrintAnalytics = {
     window.print = (function (printfn) {
       return function () {
         Analytics.send('event', 'print');
+        Analytics.ga4SendEvent('print');
         printfn();
       };
     }(window.print));

--- a/mtp_common/templates/mtp_common/mtp_base.html
+++ b/mtp_common/templates/mtp_common/mtp_base.html
@@ -23,18 +23,18 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', '{{ analytics_policy.ga4_measurement_id }}');
-
       {% comment "NOTE" %}
         This overrides the default page location/title sent to GA4.
         Some views send redacted/simplified page information.
       {% endcomment %}
       {% with default_ga_data=default_google_analytics_pageview %}
       {% with ga_data=google_analytics_pageview|default:default_ga_data %}
-        gtag('set', 'page_location', '{{ ga_data.location }}');
-        {% if ga_data.title %}
-          gtag('set', 'page_title', '{{ ga_data.title }}');
-        {% endif %}
+        gtag('config', '{{ analytics_policy.ga4_measurement_id }}', {
+          'page_location': '{{ ga_data.location }}',
+          {% if ga_data.title %}
+            'page_title': '{{ ga_data.title }}',
+          {% endif %}
+        });
       {% endwith %}
       {% endwith %}
 

--- a/mtp_common/templates/mtp_common/mtp_base.html
+++ b/mtp_common/templates/mtp_common/mtp_base.html
@@ -24,6 +24,20 @@
       gtag('js', new Date());
 
       gtag('config', '{{ analytics_policy.ga4_measurement_id }}');
+
+      {% comment "NOTE" %}
+        This overrides the default page location/title sent to GA4.
+        Some views send redacted/simplified page information.
+      {% endcomment %}
+      {% with default_ga_data=default_google_analytics_pageview %}
+      {% with ga_data=google_analytics_pageview|default:default_ga_data %}
+        gtag('set', 'page_location', '{{ ga_data.location }}');
+        {% if ga_data.title %}
+          gtag('set', 'page_title', '{{ ga_data.title }}');
+        {% endif %}
+      {% endwith %}
+      {% endwith %}
+
       {% block ga4_end %}{% endblock %}
     </script>
   {% endif %}

--- a/mtp_common/templates/mtp_common/mtp_base.html
+++ b/mtp_common/templates/mtp_common/mtp_base.html
@@ -15,6 +15,19 @@
     }
   </style>
 
+  {% if analytics_policy.ga4_enabled %}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ analytics_policy.ga4_measurement_id }}"></script>
+    <script {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', '{{ analytics_policy.ga4_measurement_id }}');
+      {% block ga4_end %}{% endblock %}
+    </script>
+  {% endif %}
+
   {% if analytics_policy.enabled %}
     <script {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -13,16 +13,19 @@ class ContextProcessorTestCase(SimpleTestCase):
         self.assertIsNone(response.context.get('GOOGLE_ANALYTICS_ID'))
         self.assertFalse(response.context.get('analytics_policy').enabled)
         self.assertIsNone(response.context.get('analytics_policy').google_analytics_id)
+        self.assertIsNone(response.context.get('analytics_policy').ga4_measurement_id)
         self.assertIsNone(response.context.get('APP'))
         self.assertIsNone(response.context.get('ENVIRONMENT'))
 
     @override_settings(GOOGLE_ANALYTICS_ID='UA-11223344-00',
+                       GA4_MEASUREMENT_ID='G-ABCDEF00AB',
                        APP='sample', ENVIRONMENT='dev',
                        APP_GIT_COMMIT='9e50f6ce3b9f5d373d726c9339bf2296d75d4eb2',
                        APP_BUILD_DATE=now_text)
     def test_context_processors_with_settings(self):
         response = self.client.get(reverse('dummy'))
         self.assertEqual(response.context.get('analytics_policy').google_analytics_id, 'UA-11223344-00')
+        self.assertEqual(response.context.get('analytics_policy').ga4_measurement_id, 'G-ABCDEF00AB')
         self.assertEqual(response.context.get('APP'), 'sample')
         self.assertEqual(response.context.get('ENVIRONMENT'), 'dev')
         self.assertEqual(response.context.get('APP_GIT_COMMIT'), '9e50f6ce3b9f5d373d726c9339bf2296d75d4eb2')


### PR DESCRIPTION
Overview of changes:
- updated `Analytics.py` to check if an app has the `GA4_MEASUREMENT_ID` setting set
  - this will be used to calculate the `ga4_enabled` property
- updated `Analytics.js` 
  - existing methods are mostly unchanged
  - added `ga4SendEvent()` method added to send a custom even named `mtp_event` with the familiar category/action/label (retain this format helps the transition to GA4)
  - added `ga4SendPageView()` method to send a `page_view` event - page views are tracked as usual but additional "page views" are sent for events across the apps
  - update mtp-common JS code sending GA events/page views to also send these to GA4 (if GA4 available in the app)
    - I could have done something within `Analytics.send()` to automagically send data to GA4 as well but I decided to keep it simple and explicit. The client code will need to update to use these new methods to start send data.
  - Installed GA4/`gtag()` in the `mtp_base` template if GA4 available.
    - the setup also set the page location/title as done in legacy GA. This means if an app decide to override the title to remove personal information this title is also used when sending page views to GA4 (to be tested)
    - added a `ga4_end` block to allow apps to inject more GA4 behaviour if they wish to do so (similar to what's allowed by the `google_analytics_end` block)
    - AFAICT this block is currently only used by the send money app to also send data to GDS' GA, but not sure how that works and what's the plan for GA4.