### PR TITLE
Bumped to 14.3.0 release

### DIFF
--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (14, 2, 0)
+VERSION = (14, 3, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Should be a non-breaking release adding functionality (GA4 support) so bump the minor number is logical.