### PR TITLE
MTP-1937: Send page path/location/title with GA4 page views

### DIFF
--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (14, 3, 0)
+VERSION = (14, 3, 1)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -52,9 +52,19 @@ export var Analytics = {
    *
    * @param {string} pageLocation page location associated to the event
    */
-  ga4SendPageView: function (pageLocation) {
+  ga4SendPageView: function (pagePath) {
     if (this._ga4Exists()) {
-      gtag.apply(window, ['event', 'page_view', { 'page_location': pageLocation || '' }]);
+      var eventParams = {
+        'page_path': pagePath,
+      };
+      var gaData = $('span.mtp-ga-data');
+      if (gaData) {
+        eventParams['page_path'] = eventParams['page_path'] || gaData.data('page');
+        eventParams['page_location'] = gaData.data('location');
+        eventParams['page_title'] = gaData.data('title') || document.title;
+      }
+
+      gtag.apply(window, ['event', 'page_view', eventParams]);
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "14.3.0",
+  "version": "14.3.1",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Only `page_location` was provided before but path wouldn't show in GA4 interface.

The `Analytics.ga4SendPageView()` method now explicitly send location, path and title (these are read from the `.mtp-ga-data` data attributes if available).