### PR TITLE
MTP-1937: Remove dependency on `django-form-error-reporting`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,6 @@ Additional Bespoke Packages
 
 There are several dependencies of the ``money-to-prisoners-common`` python library which are maintained by this team, so they may require code-changes when the dependencies (e.g. Django) of the ``money-to-prisoners-common`` python library, or any of the Prisoner Money apps, are incremented.
 
-* `django-form-error-reporting`_
 * `django-zendesk-tickets`_
 * `govuk-bank-holidays`_
 
@@ -244,7 +243,6 @@ There are additional bespoke dependencies defined as python dependencies within 
 .. _money-to-prisoners-deploy: https://github.com/ministryofjustice/money-to-prisoners-deploy
 .. _money-to-prisoners-emails: https://github.com/ministryofjustice/money-to-prisoners-emails
 .. _load_test_data.py: https://github.com/ministryofjustice/money-to-prisoners-api/blob/a6e039a3fc85d675c62658c226a3bd94d27355d5/mtp_api/apps/core/management/commands/load_test_data.py#L221-L229
-.. _django-form-error-reporting: https://github.com/ministryofjustice/django-form-error-reporting
 .. _django-zendesk-tickets: https://github.com/ministryofjustice/django-zendesk-tickets
 .. _govuk-bank-holidays: https://github.com/ministryofjustice/govuk-bank-holidays
 .. _virtualenvwrapper: https://virtualenvwrapper.readthedocs.io/

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (14, 3, 1)
+VERSION = (15, 0, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/mtp_common/auth/forms.py
+++ b/mtp_common/auth/forms.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 from requests.exceptions import ConnectionError
 
 from mtp_common.tasks import send_email
@@ -19,7 +18,7 @@ logger = logging.getLogger('mtp')
 RESET_CODE_PARAM = 'reset_code'
 
 
-class AuthenticationForm(GARequestErrorReportingMixin, forms.Form):
+class AuthenticationForm(forms.Form):
     """
     Authentication form used for authenticating users during the login process.
     """
@@ -95,7 +94,7 @@ class AuthenticationForm(GARequestErrorReportingMixin, forms.Form):
         return self.user_cache
 
 
-class PasswordChangeForm(GARequestErrorReportingMixin, forms.Form):
+class PasswordChangeForm(forms.Form):
     """
     A form that lets a user change their password by entering their old
     password.
@@ -147,7 +146,7 @@ class PasswordChangeForm(GARequestErrorReportingMixin, forms.Form):
                     raise forms.ValidationError(self.error_messages['generic'])
 
 
-class ResetPasswordForm(GARequestErrorReportingMixin, forms.Form):
+class ResetPasswordForm(forms.Form):
     error_messages = {
         'generic': _('This service is currently unavailable')
     }
@@ -183,7 +182,7 @@ class ResetPasswordForm(GARequestErrorReportingMixin, forms.Form):
                     raise forms.ValidationError(self.error_messages['generic'])
 
 
-class PasswordChangeWithCodeForm(GARequestErrorReportingMixin, forms.Form):
+class PasswordChangeWithCodeForm(forms.Form):
     """
     A form that lets a user change their password if they have a reset code.
     """
@@ -238,7 +237,7 @@ class PasswordChangeWithCodeForm(GARequestErrorReportingMixin, forms.Form):
                     raise forms.ValidationError(self.error_messages['generic'])
 
 
-class EmailChangeForm(GARequestErrorReportingMixin, forms.Form):
+class EmailChangeForm(forms.Form):
     """
     A form that lets a user change their email.
     """

--- a/mtp_common/user_admin/forms.py
+++ b/mtp_common/user_admin/forms.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.http import QueryDict
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
-from form_error_reporting import GARequestErrorReportingMixin
 
 from mtp_common.api import retrieve_all_pages_for_path
 from mtp_common.auth import api_client
@@ -16,7 +15,7 @@ from mtp_common.auth.exceptions import HttpClientError
 logger = logging.getLogger('mtp')
 
 
-class ApiForm(GARequestErrorReportingMixin, forms.Form):
+class ApiForm(forms.Form):
     error_messages = {
         'generic': _('This service is currently unavailable')
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "14.3.1",
+  "version": "15.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ install_requires = [
     'uWSGI~=2.0.21',
 
     # moj-built dependencies (should be locked versions)
-    'django-form-error-reporting==0.11',
     'django-moj-irat==0.8',
     'django-zendesk-tickets==0.16',
     'govuk-bank-holidays==0.13',


### PR DESCRIPTION
This is an internal package used to send form validation errors to GA. 

We've decided to to keep things simple and not update that package to work with the newer GA4's Measurement Protocol API.

As this is a breaking change `mtp-common`'s major version number has been bumped, new version is `15.0.0` [it is a breaking change as some of the mtp apps/forms are still using the `GARequestErrorReportingMixin` mixin until they're updated].