### PR TITLE
Attempt to upgrade to Django 3.x

### DIFF
--- a/build_tasks.py
+++ b/build_tasks.py
@@ -91,7 +91,7 @@ def setup_django_for_testing(_: Context):
         ),
         CACHES={
             'default': {
-                'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             },
         },
         CSRF_FAILURE_VIEW='mtp_common.auth.csrf.csrf_failure',

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (15, 0, 0)
+VERSION = (16, 0, 0)
 __version__ = '.'.join(map(str, VERSION))
 
 default_app_config = 'mtp_common.app.AppConfig'

--- a/mtp_common/build_tasks/executor.py
+++ b/mtp_common/build_tasks/executor.py
@@ -569,7 +569,11 @@ class Executor:
                 context.info(context.blue_style(f'\n> Running {task.name} task...'))
             if context.print_task_paths:
                 path = inspect.getfile(task.func)
-                line = inspect.getsourcelines(task.func)[1]
+                line = ''
+                try:
+                    line = inspect.getsourcelines(task.func)[1]
+                except OSError:
+                    line = '???'
 
                 context.info(context.blue_style(f'File "{path}", line {line}'))
 

--- a/mtp_common/build_tasks/executor.py
+++ b/mtp_common/build_tasks/executor.py
@@ -567,14 +567,13 @@ class Executor:
         if task.name != 'help':
             if context.print_task_names:
                 context.info(context.blue_style(f'\n> Running {task.name} task...'))
+
             if context.print_task_paths:
                 path = inspect.getfile(task.func)
-                line = ''
                 try:
                     line = inspect.getsourcelines(task.func)[1]
                 except OSError:
                     line = '???'
-
                 context.info(context.blue_style(f'File "{path}", line {line}'))
 
         os.chdir(self.root_path)

--- a/mtp_common/templatetags/mtp_common.py
+++ b/mtp_common/templatetags/mtp_common.py
@@ -9,7 +9,6 @@ from django.forms.utils import flatatt
 from django.template.base import token_kwargs
 from django.urls import NoReverseMatch, reverse
 from django.utils.crypto import get_random_string
-from django.utils.encoding import force_text
 from django.utils.html import format_html
 from django.utils.http import urlencode
 from django.utils.translation import gettext, gettext_lazy as _, override
@@ -56,7 +55,6 @@ def postcode(value):
 
 @register.filter
 def to_string(value):
-    # TODO: use force_text?
     return str(value)
 
 
@@ -111,7 +109,7 @@ def hide_long_text(text, count=5):
     if not text:
         return text
     count = int(count)
-    words = force_text(text).split()
+    words = str(text).split()
     if len(words) <= count:
         return text
     short_text, rest_text = ' '.join(words[:count]), ' '.join(words[count:])

--- a/mtp_common/test_utils/__init__.py
+++ b/mtp_common/test_utils/__init__.py
@@ -1,9 +1,5 @@
 from contextlib import contextmanager
-from unittest import mock
 import logging
-
-from django.conf import settings
-from django.core import cache as django_cache
 
 
 @contextmanager
@@ -13,19 +9,3 @@ def silence_logger(name='mtp', level=logging.CRITICAL):
     logger.setLevel(level)
     yield
     logger.setLevel(old_level)
-
-
-@contextmanager
-def local_memory_cache():
-    """Configure settings.CACHES to use LocMemCache."""
-    with mock.patch.dict(
-        settings.CACHES['default'],
-        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
-    ):
-        cache_handler = django_cache.CacheHandler()
-
-        with mock.patch.object(django_cache, 'caches', cache_handler):
-            try:
-                yield
-            finally:
-                cache_handler['default'].clear()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "15.0.0",
+  "version": "16.0.0",
   "private": true,
   "repository": {
     "type": "git",

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,10 @@ with open('README.rst') as readme:
 
 install_requires = [
     # third-party dependencies (versions should be flexible to allow for bug fixes)
-    'Django>=2.2,<2.3',  # mtp apps are only compatible with django 2.2
-    'django-extended-choices>=1.3,<2',
+    'Django>=3.2.19,<3.3',
+    'six>=1.16',  # https://docs.djangoproject.com/en/4.2/releases/3.0/#removed-private-python-2-compatibility-apis
+    # https://adamj.eu/tech/2020/01/27/moving-to-django-3-field-choices-enumeration-types/
+    # 'django-extended-choices>=1.3,<2',
     'django-widget-tweaks>=1.4,<1.5',
     'notifications-python-client~=8.0',
     'pytz>=2022.7',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ with open('README.rst') as readme:
 install_requires = [
     # third-party dependencies (versions should be flexible to allow for bug fixes)
     'Django>=3.2.19,<3.3',
-    'six>=1.16',  # https://docs.djangoproject.com/en/4.2/releases/3.0/#removed-private-python-2-compatibility-apis
     # https://adamj.eu/tech/2020/01/27/moving-to-django-3-field-choices-enumeration-types/
     # 'django-extended-choices>=1.3,<2',
     'django-widget-tweaks>=1.4,<1.5',

--- a/tests/test_auth_forms.py
+++ b/tests/test_auth_forms.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 from django.conf import settings
 from django.test.testcases import SimpleTestCase
-from django.utils.encoding import force_text
 import responses
 
 from mtp_common.auth import urljoin
@@ -45,7 +44,7 @@ class AuthenticationFormTestCase(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(
             form.non_field_errors(),
-            [force_text(form.error_messages['invalid_login'])]
+            [str(form.error_messages['invalid_login'])]
         )
 
         mocked_authenticate.assert_called_with(**data)

--- a/tests/test_auth_views.py
+++ b/tests/test_auth_views.py
@@ -4,7 +4,6 @@ from django.conf import settings
 from django.http.request import QueryDict
 from django.test import SimpleTestCase
 from django.urls import reverse, reverse_lazy
-from django.utils.encoding import force_text
 import responses
 
 from mtp_common.auth import SESSION_KEY, BACKEND_SESSION_KEY, \
@@ -81,7 +80,7 @@ class LoginViewTestCase(SimpleTestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(
             form.errors['__all__'],
-            [force_text(form.error_messages['invalid_login'])]
+            [str(form.error_messages['invalid_login'])]
         )
         self.assertEqual(len(self.client.session.items()), 0)  # nothing in the session
 
@@ -103,7 +102,7 @@ class LoginViewTestCase(SimpleTestCase):
         form = response.context_data['form']
         self.assertFalse(form.is_valid(), msg='user should not be able to log in if they are'
                                               'forbidden from accessing that application')
-        self.assertEqual(form.errors['__all__'], [force_text(form.error_messages['application_inaccessible'])],
+        self.assertEqual(form.errors['__all__'], [str(form.error_messages['application_inaccessible'])],
                          msg='user should see error message if they are forbidden'
                              'from accessing that application')
 

--- a/tests/test_nomis.py
+++ b/tests/test_nomis.py
@@ -346,6 +346,9 @@ class GetAccountBalancesTestCase(BaseTestCase):
     Tests related to the get_account_balances function.
     """
 
+    def setUp(self):
+        django_cache.cache.clear()
+
     def test_call(self):
         """
         Test that the function connects to Prison API (i.e. NOMIS) and gets the expected data.
@@ -387,6 +390,9 @@ class GetTransactionHistoryTestCase(BaseTestCase):
             },
         ],
     }
+
+    def setUp(self):
+        django_cache.cache.clear()
 
     def test_date_converted_to_string(self):
         """
@@ -493,6 +499,9 @@ class GetPhotographDataTestCase(BaseTestCase):
     Tests related to the get_photograph_data function.
     """
 
+    def setUp(self):
+        django_cache.cache.clear()
+
     def test_call(self):
         """
         Test that the function connects to Prison API (i.e. NOMIS) and gets the expected data.
@@ -534,6 +543,9 @@ class GetLocationTestCase(BaseTestCase):
     """
     Tests related to the get_location function.
     """
+
+    def setUp(self):
+        django_cache.cache.clear()
 
     def _test_get_location_scenario(self, nomis_mocked_response, expected_location_dict):
         with responses.RequestsMock() as rsps:

--- a/tests/test_nomis.py
+++ b/tests/test_nomis.py
@@ -9,7 +9,7 @@ import responses
 
 from mtp_common import nomis
 from mtp_common.auth import urljoin
-from mtp_common.test_utils import local_memory_cache, silence_logger
+from mtp_common.test_utils import silence_logger
 
 
 def build_prison_api_v1_url(path):
@@ -175,6 +175,9 @@ class BaseTestCase(SimpleTestCase):
     Base class for testing Prison API (i.e. NOMIS).
     """
 
+    def setUp(self):
+        django_cache.cache.clear()
+
     def _mock_successful_auth_request(self, rsps, token='my-token'):
         rsps.add(
             responses.POST,
@@ -218,7 +221,6 @@ class PrisonApiTestCase(BaseTestCase):
             with override_settings(**{key: ''}):
                 self.assertFalse(nomis.can_access_nomis())
 
-    @local_memory_cache()
     def test_token_cached(self):
         """
         Test that the token is cached when making a Prison API (i.e. NOMIS) call.
@@ -244,7 +246,6 @@ class PrisonApiTestCase(BaseTestCase):
             'my-token',
         )
 
-    @local_memory_cache()
     def test_gets_token_from_cache(self):
         """
         Test that any cached token is used when making a Prison API (i.e. NOMIS) call.
@@ -269,7 +270,6 @@ class PrisonApiTestCase(BaseTestCase):
             'some-token',
         )
 
-    @local_memory_cache()
     def test_retries_after_401_response(self):
         """
         Test that if a request returns 401, the logic invalidates the cached token
@@ -304,7 +304,6 @@ class PrisonApiTestCase(BaseTestCase):
             'my-token',
         )
 
-    @local_memory_cache()
     def test_doesnt_retry_more_than_once_after_401_response(self):
         """
         Test that if a request returns 401, the logic invalidates the cached token
@@ -345,9 +344,6 @@ class GetAccountBalancesTestCase(BaseTestCase):
     """
     Tests related to the get_account_balances function.
     """
-
-    def setUp(self):
-        django_cache.cache.clear()
 
     def test_call(self):
         """
@@ -390,9 +386,6 @@ class GetTransactionHistoryTestCase(BaseTestCase):
             },
         ],
     }
-
-    def setUp(self):
-        django_cache.cache.clear()
 
     def test_date_converted_to_string(self):
         """
@@ -499,9 +492,6 @@ class GetPhotographDataTestCase(BaseTestCase):
     Tests related to the get_photograph_data function.
     """
 
-    def setUp(self):
-        django_cache.cache.clear()
-
     def test_call(self):
         """
         Test that the function connects to Prison API (i.e. NOMIS) and gets the expected data.
@@ -543,9 +533,6 @@ class GetLocationTestCase(BaseTestCase):
     """
     Tests related to the get_location function.
     """
-
-    def setUp(self):
-        django_cache.cache.clear()
 
     def _test_get_location_scenario(self, nomis_mocked_response, expected_location_dict):
         with responses.RequestsMock() as rsps:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -24,7 +24,7 @@ class NotificationTestCase(SimpleTestCase):
             )
         )
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
+    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_unauthenticated_user_access(self):
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -46,7 +46,7 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertIn('Test', response_content)
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
+    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_authenticated_user_access(self):
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -68,7 +68,7 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertIn('Test', response_content)
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
+    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_api_errors_do_not_appear_on_page(self):
         with responses.RequestsMock() as rsps, silence_logger():
             rsps.add(
@@ -86,7 +86,7 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertEqual(response_content, '')
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.dummy.DummyCache'}})
+    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_can_cascade_to_fallback_notification_targets(self):
         with responses.RequestsMock() as rsps:
             rsps.add(

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from django.conf import settings
 from django.core.cache import cache
-from django.test import override_settings
 import responses
 
 from mtp_common.auth import urljoin, MojAnonymousUser
@@ -24,7 +23,6 @@ class NotificationTestCase(SimpleTestCase):
             )
         )
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_unauthenticated_user_access(self):
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -46,7 +44,6 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertIn('Test', response_content)
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_authenticated_user_access(self):
         with responses.RequestsMock() as rsps:
             rsps.add(
@@ -68,7 +65,6 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertIn('Test', response_content)
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_api_errors_do_not_appear_on_page(self):
         with responses.RequestsMock() as rsps, silence_logger():
             rsps.add(
@@ -86,7 +82,6 @@ class NotificationTestCase(SimpleTestCase):
         response_content = response.content.decode(response.charset).strip()
         self.assertEqual(response_content, '')
 
-    @override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
     def test_can_cascade_to_fallback_notification_targets(self):
         with responses.RequestsMock() as rsps:
             rsps.add(


### PR DESCRIPTION
We can merge these Django 3.2 changes into the `16.x` branch and release as `16.0.0` - this would allow us to test the applications more easily (and would make iterating changes there easier as tests could run in CI)

**NOTE**: Production applications would continue to use `mtp-common` `15.x` for the time being while we do some manual testing on the versions using Django 3.2.