### PR TITLE
MTP-1937: Remove legacy GA code

### DIFF
--- a/mtp_common/analytics.py
+++ b/mtp_common/analytics.py
@@ -17,11 +17,7 @@ class AnalyticsPolicy:
 
     def __init__(self, request):
         analytics_required = getattr(settings, 'ANALYTICS_REQUIRED', True)
-
-        self.google_analytics_id = getattr(settings, 'GOOGLE_ANALYTICS_ID', None)
         self.ga4_measurement_id = getattr(settings, 'GA4_MEASUREMENT_ID', None)
-
-        self.enabled = self.google_analytics_id and (analytics_required or self.is_cookie_policy_accepted(request))
         self.ga4_enabled = self.ga4_measurement_id and (analytics_required or self.is_cookie_policy_accepted(request))
 
     def is_cookie_policy_accepted(self, request):

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -1,6 +1,7 @@
 // Google Analytics Utility module
 // This module offers ways to send custom events to Google Analytics:
-// - by calling Analytics.send. Eg. Analytics.send('event', 'tick', 'checkbox')
+// - by calling Analytics.ga4SendEvent(). Eg. Analytics.ga4SendEvent('event', 'tick', 'checkbox')
+// - by calling Analytics.ga4SendPageView(). Eg. Analytics.ga4SendPageView(pagePath)
 // - by adding the data-analytics attribute to any element that can be clicked
 //   eg <div data-analytics="pageview,/virtual/pageview/,user clicked there"/>
 // It needs the google analytics tracking code to be enabled on the page
@@ -45,9 +46,9 @@ export var Analytics = {
     }
   },
 
-  /** Sends a GA4 'page_view' event with the give 'page_location'
+  /** Sends a GA4 'page_view' event with the give 'page_path'
    *
-   * @param {string} pageLocation page location associated to the event
+   * @param {string} pagePath page path associated to the event
    */
   ga4SendPageView: function (pagePath) {
     if (this._ga4Exists()) {
@@ -97,6 +98,8 @@ export var Analytics = {
 
   /**
    * Returns true if GA4's `gtag()` is available
+   *
+   * @private
    *
    * @returns {boolean} true if GA4 is available
    */

--- a/mtp_common/assets-src/mtp_common/components/analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/analytics/index.js
@@ -4,7 +4,7 @@
 // - by adding the data-analytics attribute to any element that can be clicked
 //   eg <div data-analytics="pageview,/virtual/pageview/,user clicked there"/>
 // It needs the google analytics tracking code to be enabled on the page
-/* globals ga gtag */
+/* globals gtag */
 'use strict';
 
 export var Analytics = {
@@ -12,9 +12,6 @@ export var Analytics = {
   ga4EventName: 'mtp_event',
 
   init: function () {
-    if (this._gaExists()) {
-      $('*[data-' + this.attrName + ']').on('click', $.proxy(this._sendFromEvent, this));
-    }
     if (this._ga4Exists()) {
       $('*[data-' + this.attrName + ']').on('click', $.proxy(this._ga4SendFromEvent, this));
     }
@@ -68,58 +65,6 @@ export var Analytics = {
     }
   },
 
-  /**
-   * Sends a legacy GA custom event or `pageview` event
-   *
-   * @deprecated GA is deprecated in favour of GA4, use `ga4SendEvent()` or `ga4SendPageView()` instead
-   */
-  send: function () {
-    /*
-      Sends to GA passing through all specified arguments.
-      It appends an object with page, location and title to the call, if you don't want
-      this use rawSend instead.
-    */
-    if (this._gaExists()) {
-      var gaData = $('span.mtp-ga-data');
-      if (gaData) {
-        var page = gaData.data('page');
-        if (arguments[0] === 'pageview' && arguments.length > 1 && $.type(arguments[1]) === 'string') {
-          page = arguments[1];
-        }
-        var gaOverride = {
-          page: page,
-          location: gaData.data('location'),
-          title: gaData.data('title') || document.title
-        };
-        [].push.call(arguments, gaOverride);
-      }
-      [].unshift.call(arguments, 'send');
-      ga.apply(window, arguments);
-    }
-  },
-
-  /**
-   * Sends a legacy GA custom event or `pageview` event
-   *
-   * @deprecated GA is deprecated in favour of GA4, use `ga4SendEvent()` or `ga4SendPageView()` instead
-   */
-  rawSend: function () {
-    /*
-      Sends to GA passing through all specified arguments.
-      Unlike send, it does NOT modify any arguments.
-    */
-    if (this._gaExists()) {
-      [].unshift.call(arguments, 'send');
-      ga.apply(window, arguments);
-    }
-  },
-
-  _sendFromEvent: function (event) {
-    var analyticsParams = $(event.currentTarget).data(this.attrName).split(',');
-    this.send.apply(this, analyticsParams);
-    return true;
-  },
-
   /** Event handler attached to `data-analytics`'s clicks
    *
    * the `data-analytics` attribute value determines whether a custom `mtp_event` is sent or a
@@ -148,15 +93,6 @@ export var Analytics = {
     }
 
     return true;
-  },
-
-  /**
-   * Returns true if GA's `ga()` (legacy) is available
-   *
-   * @returns {boolean} true if GA is available
-   */
-  _gaExists: function () {
-    return typeof ga === typeof Function;
   },
 
   /**

--- a/mtp_common/assets-src/mtp_common/components/autocomplete-select/index.js
+++ b/mtp_common/assets-src/mtp_common/components/autocomplete-select/index.js
@@ -107,13 +107,6 @@ export var AutocompleteSelect = {
               var eventCategory = $hiddenInput.data('event-category');
               var eventAction = 'Autocomplete';
               var eventLabel = $visualInput.val() + ' > ' + suggestion.name;
-              Analytics.send(
-                'event', {
-                  eventCategory: eventCategory,
-                  eventAction: eventAction,
-                  eventLabel: eventLabel,
-                }
-              );
               Analytics.ga4SendEvent(eventCategory, eventAction, eventLabel);
             }
 

--- a/mtp_common/assets-src/mtp_common/components/before-unload/index.js
+++ b/mtp_common/assets-src/mtp_common/components/before-unload/index.js
@@ -27,7 +27,6 @@ export var BeforeUnload = {
       $(window).on('beforeunload', function () {
         if ($form.serialize() !== initialData && !submitting) {
           var pageLocation = '/-leaving_page_dialog/';
-          Analytics.send('pageview', pageLocation);
           Analytics.ga4SendPageView(pageLocation);
           return message;
         }

--- a/mtp_common/assets-src/mtp_common/components/print-analytics/index.js
+++ b/mtp_common/assets-src/mtp_common/components/print-analytics/index.js
@@ -10,7 +10,6 @@ export var PrintAnalytics = {
     }
     window.print = (function (printfn) {
       return function () {
-        Analytics.send('event', 'print');
         Analytics.ga4SendEvent('print');
         printfn();
       };

--- a/mtp_common/templates/mtp_common/mtp_base.html
+++ b/mtp_common/templates/mtp_common/mtp_base.html
@@ -41,27 +41,6 @@
       {% block ga4_end %}{% endblock %}
     </script>
   {% endif %}
-
-  {% if analytics_policy.enabled %}
-    <script {% if csp_nonce %}nonce="{{ csp_nonce }}"{% endif %}>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', '{{ analytics_policy.google_analytics_id }}', 'auto');
-
-      {% with default_ga_data=default_google_analytics_pageview %}
-      {% with ga_data=google_analytics_pageview|default:default_ga_data %}
-        {% for key, value in ga_data.items %}
-          {% if value %}ga('set', '{{ key }}', '{{ value }}');{% endif %}
-        {% endfor %}
-      {% endwith %}
-      {% endwith %}
-
-      ga('send', 'pageview');
-      {% block google_analytics_end %}{% endblock %}
-    </script>
-  {% endif %}
 {% endblock %}
 
 {% block body_classes %}{{ block.super }} {% if moj_internal_site %}mtp-internal-site{% endif %}{% endblock %}

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -7,7 +7,7 @@ from mtp_common.analytics import AnalyticsPolicy, genericised_pageview
 from tests.utils import SimpleTestCase
 
 
-@override_settings(GOOGLE_ANALYTICS_ID='ABC123')
+@override_settings(GA4_MEASUREMENT_ID='ABC123')
 class CookiePolicyTestCase(SimpleTestCase):
     template = """
     {% extends 'mtp_common/mtp_base.html' %}

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -10,21 +10,19 @@ class ContextProcessorTestCase(SimpleTestCase):
     @override_settings(APP=None, ENVIRONMENT=None)
     def test_context_processors_with_empty_settings(self):
         response = self.client.get(reverse('dummy'))
-        self.assertIsNone(response.context.get('GOOGLE_ANALYTICS_ID'))
-        self.assertFalse(response.context.get('analytics_policy').enabled)
-        self.assertIsNone(response.context.get('analytics_policy').google_analytics_id)
+        self.assertIsNone(response.context.get('GA4_MEASUREMENT_ID'))
+        self.assertFalse(response.context.get('analytics_policy').ga4_enabled)
         self.assertIsNone(response.context.get('analytics_policy').ga4_measurement_id)
         self.assertIsNone(response.context.get('APP'))
         self.assertIsNone(response.context.get('ENVIRONMENT'))
 
-    @override_settings(GOOGLE_ANALYTICS_ID='UA-11223344-00',
-                       GA4_MEASUREMENT_ID='G-ABCDEF00AB',
+    @override_settings(GA4_MEASUREMENT_ID='G-ABCDEF00AB',
                        APP='sample', ENVIRONMENT='dev',
                        APP_GIT_COMMIT='9e50f6ce3b9f5d373d726c9339bf2296d75d4eb2',
                        APP_BUILD_DATE=now_text)
     def test_context_processors_with_settings(self):
         response = self.client.get(reverse('dummy'))
-        self.assertEqual(response.context.get('analytics_policy').google_analytics_id, 'UA-11223344-00')
+        self.assertTrue(response.context.get('analytics_policy').ga4_enabled)
         self.assertEqual(response.context.get('analytics_policy').ga4_measurement_id, 'G-ABCDEF00AB')
         self.assertEqual(response.context.get('APP'), 'sample')
         self.assertEqual(response.context.get('ENVIRONMENT'), 'dev')


### PR DESCRIPTION
- `Analytics.js`: removed deprecated methods/updated docs
- `AnalyticsPolicy`: removed legacy GA policy/updated tests
- base template: removed legacy GA tracking code

⚠️ NOTE: These are _potentially_ breaking changes and that's why this PR is on top of the 16.x branch rather than `main`.