### PR TITLE
MTP-1976: Update security check rejection categories

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,8 @@
 Money to Prisoners Common
 =========================
 
-This version of `money-to-prisoners-common` is using Django 3.2 and is currently
-experimental.
-
 A Django app containing utilities and assets common to all Prisoner Money applications.
+This version is only tested with Django 3.2.
 
 .. image:: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common.svg?style=svg
     :target: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common

--- a/mtp_common/security/checks.py
+++ b/mtp_common/security/checks.py
@@ -8,7 +8,7 @@ logger = logging.getLogger('mtp')
 # NB: you cannot remove keys as they will have been persisted in the database,
 #     instead remove fields from the form in noms-ops as necessary
 CHECK_REJECTION_TEXT_CATEGORY_LABELS = {
-    'fiu_investigation_id': _('Associated FIU investigation'),
+    'fiu_investigation_id': _('Associated FIU investigation'),  # no longer used
     'intelligence_report_id': _('Associated intelligence report (IR)'),
     'other_reason': _('Other reason'),
 }
@@ -19,15 +19,12 @@ CHECK_REJECTION_BOOL_CATEGORY_LABELS = {
     'payment_source_paying_multiple_prisoners': _('Payment source is paying multiple prisoners'),
     'payment_source_multiple_cards': _('Payment source is using multiple cards'),
     'payment_source_linked_other_prisoners': _('Payment source is linked to other prisoner/s'),
-    'payment_source_known_email': _('Payment source is using a known email'),
+    'payment_source_known_email': _('Payment source is using a known email'),  # no longer used
+    'payment_source_monitored_partial_email': _('Payment source is using a monitored keyword in the email address'),
     'payment_source_unidentified': _('Payment source is unidentified'),
     'prisoner_multiple_payments_payment_sources': _('Prisoner has multiple payments or payment sources'),
+    'fraud': _('Potential fraud'),
 }
-
-# all known security check rejection reason categories
-CHECK_REJECTION_CATEGORIES = (
-    frozenset(CHECK_REJECTION_TEXT_CATEGORY_LABELS) | frozenset(CHECK_REJECTION_BOOL_CATEGORY_LABELS)
-)
 
 
 def human_readable_check_rejection_reasons(rejection_reasons: dict) -> list:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require = {
         # 'flake8-logging~=1.2',
         'flake8-quotes~=3.3',
         'pep8-naming~=0.13.3',
-        'responses~=0.23.3',
+        'responses~=0.24.0',
         'twine~=4.0',
         'watchdog~=3.0',
     ],


### PR DESCRIPTION
• Remove 'known email' reason
• Add 'using a monitored keyword or email address'
• Remove 'associated FIU investigation' reason
• Add 'potential fraud'