### PR TITLE
Update GOV.UK Notify client and allow specifying download file name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,24 @@ updates:
       - dependency-name: kubernetes
         versions:
           - ">=27"
+    groups:
+      minor-updates:
+        update-types: [minor, patch]
     schedule:
       interval: monthly
     pull-request-branch-name:
       separator: '-'
   - package-ecosystem: npm
     directory: /
+    groups:
+      minor-updates:
+        update-types: [minor, patch]
     schedule:
       interval: monthly
   - package-ecosystem: npm
     directory: /mtp_common/templates/mtp_common/build_tasks
+    groups:
+      minor-updates:
+        update-types: [minor, patch]
     schedule:
       interval: monthly

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = [
     # third-party dependencies (versions should be flexible to allow for bug fixes)
     'Django>=3.2.23,<3.3',
     'django-widget-tweaks>=1.5,<1.6',
-    'notifications-python-client~=8.1',
+    'notifications-python-client~=9.0',
     'pytz>=2023.3',
     'requests~=2.31',
     'requests-oauthlib~=1.3',

--- a/tests/test_notify-simple.csv
+++ b/tests/test_notify-simple.csv
@@ -1,0 +1,2 @@
+Name,Email
+John,john@mtp.local

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -150,20 +150,26 @@ class NotifyTestCase(NotifyBaseTestCase):
         with responses.RequestsMock() as rsps:
             mock_all_templates_response(rsps, templates=[
                 fake_template('0000', 'generic', required_personalisations=['message']),
-                fake_template('333', 'two-files', required_personalisations=['open file', 'byte content']),
+                fake_template('333', 'two-files', required_personalisations=['path', 'open file', 'byte content']),
             ])
             client = NotifyClient.shared_client()
             mock_send_email_response(rsps, '333', 'sample@localhost', personalisation={
+                'path': {
+                    'file': 'TmFtZSxFbWFpbApKb2huLGpvaG5AbXRwLmxvY2FsCg==', 'filename': 'test_notify-simple.csv',
+                    'confirm_email_before_download': False, 'retention_period': '52 weeks',
+                },
                 'open file': {
-                    'file': 'AAAAAAA=', 'is_csv': False,
+                    'file': 'AAAAAAA=', 'filename': None,
                     'confirm_email_before_download': False, 'retention_period': '52 weeks',
                 },
                 'byte content': {
-                    'file': 'MTIzNDU=', 'is_csv': False,
+                    'file': 'MTIzNDU=', 'filename': None,
                     'confirm_email_before_download': False, 'retention_period': '52 weeks',
                 },
             })
             client.send_email('two-files', 'sample@localhost', personalisation={
+                # passes a path
+                'path': pathlib.Path(__file__).parent / 'test_notify-simple.csv',
                 # passes an open file handle
                 'open file': (pathlib.Path(__file__).parent / 'test_notify-5-null-bytes.bin').open('rb'),
                 # passes byte content directly


### PR DESCRIPTION
Ref:
- [docs](https://docs.notifications.service.gov.uk/python.html#set-the-filename)
- [changes](https://github.com/alphagov/notifications-python-client/compare/8.2.0...9.0.0)