### PR TITLE
Bump twine to latest version (6.1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ extras_require = {
         'flake8-quotes~=3.4',
         'pep8-naming~=0.14.1',
         'responses~=0.25',
-        'twine~=5.1',
+        'twine~=6.1',
         'watchdog~=5.0',
     ],
 }


### PR DESCRIPTION
[Attemp to release] mtp-common via the GH release/action is currently not working and throwing this exception:

```
Uploading distributions to https://upload.pypi.org/legacy/
ERROR    InvalidDistribution: Metadata is missing required fields: Name,
         Version.
         Make sure the distribution includes the files where those fields are
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,
Shell command `twine upload --non-interactive dist/*` exited with error code: 1
         2.0, 2.1, 2.2, 2.3.
```

Not sure why this started to happen as we haven't touched the version of twine in awhile. However one of the suggestion in [this GH] is to upgrade to the latest version of twine which this commit is doing.

**NOTE**: I don't see anything particularly harmful in [the Twine changelog] even tho it's a major version bump.

[Attemp to release]: https://github.com/ministryofjustice/money-to-prisoners-common/actions/runs/13995520106/job/39356827072
[this GH]: https://github.com/pypi/warehouse/issues/15611
[the Twine changelog]: https://twine.readthedocs.io/en/stable/changelog.html