### PR TITLE
README tweak and align version to GH releases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Money to Prisoners Common
 =========================
 
 A Django app containing utilities and assets common to all Prisoner Money applications.
-This version is only tested with Django 3.2.
+This version is only tested with Django 5.1.
 
 .. image:: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common.svg?style=svg
     :target: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (19, 0, 1)
+VERSION = (19, 0, 2)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
- README no longer mentions Django 3.2
- package version is aligned to latest GH release version (even tho PyPi latest and greatest is `19.0.1`)