### PR TITLE
20.0.0: Bump to Django 5.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Money to Prisoners Common
 =========================
 
 A Django app containing utilities and assets common to all Prisoner Money applications.
-This version is only tested with Django 5.1.
+This version is only tested with Django 5.2.
 
 .. image:: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common.svg?style=svg
     :target: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (19, 1, 0)
+VERSION = (20, 0, 0)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('README.rst') as readme:
 
 install_requires = [
     # third-party dependencies (versions should be flexible to allow for bug fixes)
-    'Django>=5.1.7,<5.2',
+    'Django>=5.2.0,<5.3',
 
     'django-widget-tweaks>=1.5,<1.6',
     'notifications-python-client>=10,<11',
@@ -35,8 +35,8 @@ install_requires = [
     'uWSGI~=2.0.28',
 
     # moj-built dependencies (should be locked versions)
-    'django-moj-irat==0.10',
-    'django-zendesk-tickets==0.18',
+    'django-moj-irat==0.11',
+    'django-zendesk-tickets==0.19',
     'govuk-bank-holidays==0.15',
 ]
 extras_require = {


### PR DESCRIPTION
Also use newer versions of `django-moj-irat` and
`django-zendesk-tickets`: These versions only update package metadata necessary to install alongside
Django 5.2, nothing should change.