### PR TITLE
JIRA-1694 Combine dependabot dependency updates

### DIFF
--- a/mtp_common/templates/mtp_common/build_tasks/package.json
+++ b/mtp_common/templates/mtp_common/build_tasks/package.json
@@ -18,7 +18,7 @@
     "browser-sync": "~3.0",
     "@eslint/js": "~10.0",
     "eslint": "~9.39",
-    "globals": "~17.4",
+    "globals": "~17.6",
     "sass-lint": "~1.13"
   },
   "dependencies": {

--- a/mtp_common/templates/mtp_common/build_tasks/package.json
+++ b/mtp_common/templates/mtp_common/build_tasks/package.json
@@ -26,7 +26,7 @@
     "jquery": "~4.0",
     "js-cookie": "~3.0",
     "mailcheck": "~1.1",
-    "webpack": "~5.105",
+    "webpack": "~5.107",
     "webpack-cli": "~6.0"
   }
 }

--- a/mtp_common/templates/mtp_common/build_tasks/package.json
+++ b/mtp_common/templates/mtp_common/build_tasks/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "browser-sync": "~3.0",
     "@eslint/js": "~10.0",
-    "eslint": "~9.39",
+    "eslint": "~10.4",
     "globals": "~17.4",
     "sass-lint": "~1.13"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@eslint/js": "~10.0",
     "eslint": "~10.2",
-    "globals": "~17.4",
+    "globals": "~17.6",
     "sass-lint": "~1.13"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'Django>=5.2.7,<5.3',
 
     'django-widget-tweaks>=1.5,<1.6',
-    'notifications-python-client>=10,<11',
+    'notifications-python-client>=10,<13',
     'requests~=2.32',
     'requests-oauthlib~=2.0',
     'slumber>=0.7,<0.8',


### PR DESCRIPTION
Combines five dependabot dependency-update PRs into a single branch so they can be reviewed and merged together.

## Included updates

- **#764** — `notifications-python-client` `>=10,<11` → `>=10,<13` (`setup.py`)
- **#760** — `globals` `17.4.0` → `17.6.0` (root `package.json`)
- **#763** — `globals` `17.4.0` → `17.6.0` (`mtp_common/templates/mtp_common/build_tasks/package.json`)
- **#762** — `eslint` `9.39.4` → `10.4.0` (`build_tasks/package.json`)
- **#761** — `webpack` `5.105.4` → `5.107.2` (`build_tasks/package.json`)

## Notes

- The `eslint` bump conflicted with the `globals` bump in `build_tasks/package.json`; resolved to keep both (`eslint ~10.4`, `globals ~17.6`).
- Lock files are not tracked in this repo (regenerated at build time), so only `package.json`/`setup.py` are changed.

Closes #764, #763, #762, #761, #760