### PR TITLE
JIRA-1701 Publish to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,15 @@ name: Release to PYPI
 on:
   release:
     types: [created]
+permissions:
+  contents: read
 jobs:
   release:
     name: Release to PYPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for PyPI trusted publishing (OIDC)
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -23,8 +28,7 @@ jobs:
         run: |
           pip install -U setuptools pip wheel
           pip install --editable .[testing]
-      - name: Build and upload to PYPI
-        run: python run.py upload
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      - name: Build distributions
+        run: python run.py build_dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/build_tasks.py
+++ b/build_tasks.py
@@ -212,11 +212,18 @@ def docs(context: Context):
 
 
 @tasks.register('clean', 'build')
-def upload(context: Context):
+def build_dist(context: Context):
     """
-    Builds and uploads MTP-common to pypi
+    Builds MTP-common source and wheel distributions into dist/
     """
     context.shell(sys.executable, 'setup.py', 'sdist', 'bdist_wheel')
+
+
+@tasks.register('build_dist')
+def upload(context: Context):
+    """
+    Builds and uploads MTP-common to pypi (manual/local release; CI uses trusted publishing)
+    """
     context.shell('twine', 'upload', '--non-interactive', 'dist/*')
 
 

--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (21, 2, 3)
+VERSION = (21, 2, 4)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "21.2.3",
+  "version": "21.2.4",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The **Release to PYPI** workflow uploaded with `twine` using `PYPI_USERNAME`/`PYPI_PASSWORD` secrets that date from 2023. PyPI no longer accepts username/password uploads, so the last release attempt (21.2.2) failed and the workflow was subsequently disabled. As a result 21.2.2 and 21.2.3 were tagged/released on GitHub but never published to PyPI.

## Changes

- **`.github/workflows/release.yml`** — switch from `twine` + stored credentials to [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) via `pypa/gh-action-pypi-publish`. Adds `id-token: write` permission; no PyPI credentials are stored anymore.
- **`build_tasks.py`** — split a `build_dist` task out of `upload`, so CI builds the sdist/wheel and the publish action uploads them. `upload` (twine) is kept for manual/local releases.
- **Version bump to 21.2.4** — a `release`-triggered workflow reads its YAML from the release tag, so the next release needs a tag that contains the new workflow (the existing 21.2.3 tag predates it).

## Required before this can publish

A trusted publisher must be configured on PyPI for project `money-to-prisoners-common`:
- Owner: `ministryofjustice`
- Repository: `money-to-prisoners-common`
- Workflow: `release.yml`
- Environment: *(none)*

## After merge

1. Re-enable the manually-disabled **Release to PYPI** workflow.
2. Tag `21.2.4` on the merge commit and create the GitHub release → triggers OIDC publish to PyPI.