### PR TITLE
JIRA-1694 Pin govuk-frontend back to ~5.13 for LibSass compatibility

### DIFF
--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (21, 2, 4)
+VERSION = (21, 2, 5)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/mtp_common/templates/mtp_common/build_tasks/package.json
+++ b/mtp_common/templates/mtp_common/build_tasks/package.json
@@ -22,7 +22,7 @@
     "sass-lint": "~1.13"
   },
   "dependencies": {
-    "govuk-frontend": "~6.1",
+    "govuk-frontend": "~5.13",
     "jquery": "~4.0",
     "js-cookie": "~3.0",
     "mailcheck": "~1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "21.2.4",
+  "version": "21.2.5",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

`mtp_common` compiles stylesheets with **LibSass** (`bundle_stylesheets` → `import sass`). govuk-frontend **6.x requires Dart Sass**: its sass uses the module system (`list.append` in `settings/_warnings.scss`) and removed the `settings/all` entry point. LibSass has no module support, so any app building assets against the `~6.1` pin fails:

```
Error: Invalid CSS after "...-warnings: list": expected expression, was ".append($govuk-supp"
  on line 55 of node_modules/govuk-frontend/dist/govuk/settings/_warnings.scss
```

(Surfaced by money-to-prisoners-api PR #869, the first API build to do a clean npm install against govuk 6.x.)

## Fix

Pin `govuk-frontend` back to `~5.13` — the last release that compiles under LibSass (verified: `settings/_all.scss` exists and no module syntax in the imported files; the api `performance-dashboard.scss` compiles under `libsass` + `govuk-frontend@5.13.0`). Bump to **21.2.5**.

This is a stop-gap. The proper long-term fix is migrating `bundle_stylesheets` from LibSass to Dart Sass, after which govuk-frontend 6.x can be adopted.

## Follow-ups

- Add a Dependabot ignore for `govuk-frontend` major `>= 6` so it doesn't immediately re-bump.
- Track the Dart Sass migration separately.