### PR TITLE
JIRA-1694 Stop Dependabot bumping govuk-frontend to 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
     directories:
       - /
       - /mtp_common/templates/mtp_common/build_tasks
+    ignore:
+      # govuk-frontend 6.x requires Dart Sass; the build uses LibSass. Pin to 5.x
+      # until bundle_stylesheets is migrated to Dart Sass.
+      - dependency-name: govuk-frontend
+        versions:
+          - '>=6'
     groups:
       minor-updates:
         update-types: [minor, patch]


### PR DESCRIPTION
The Dependabot ignore rule from #767 was left out when that PR merged at its first commit. This re-adds it.

govuk-frontend 6.x requires Dart Sass but the asset build uses LibSass, so ignore major `>=6` (in both `/` and `/mtp_common/templates/mtp_common/build_tasks`) until `bundle_stylesheets` is migrated to Dart Sass. Without this, Dependabot will immediately re-raise the govuk-frontend 6.x bump that #767 reverted.