### PR TITLE
IR-1734 Point 'Forgotten your password?' link to ServiceNow

### DIFF
--- a/mtp_common/__init__.py
+++ b/mtp_common/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (21, 2, 5)
+VERSION = (21, 2, 6)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/mtp_common/context_processors.py
+++ b/mtp_common/context_processors.py
@@ -19,6 +19,7 @@ def app_environment(_):
         'APP_BUILD_DATE': getattr(settings, 'APP_BUILD_DATE', None),
         'APP_GIT_COMMIT': app_git_commit,
         'APP_GIT_COMMIT_SHORT': (app_git_commit or 'unknown')[:7],
+        'servicenow_password_reset_url': getattr(settings, 'SERVICENOW_PASSWORD_RESET_URL', ''),
     }
 
 

--- a/mtp_common/templates/mtp_common/auth/login.html
+++ b/mtp_common/templates/mtp_common/auth/login.html
@@ -30,9 +30,8 @@
         </div>
       </form>
 
-      {% url 'reset_password' as reset_password_url %}
-      {% if reset_password_url %}
-        <p><a href="{{ reset_password_url }}">{% trans 'Forgotten your password?' %}</a></p>
+      {% if servicenow_password_reset_url %}
+        <p><a href="{{ servicenow_password_reset_url }}">{% trans 'Forgotten your password?' %}</a></p>
       {% endif %}
 
     </div>


### PR DESCRIPTION
## What
Move the shared staff sign-in 'Forgotten your password?' link off the internal reset flow and onto the new ServiceNow catalogue item, as part of migrating support logging from Zendesk to ServiceNow.

## Changes
- Add `servicenow_password_reset_url` to the `app_environment` context processor, sourced from a new `SERVICENOW_PASSWORD_RESET_URL` setting (empty default, so apps that don't set it keep hiding the link).
- Update `mtp_common/auth/login.html` to link to `servicenow_password_reset_url` instead of the `reset_password` URL.
- Bump version to 21.2.6.

## Notes
Consuming apps must define `SERVICENOW_PASSWORD_RESET_URL` for the link to appear. Bank admin relies on this release (its `~=21.2.1` pin accepts 21.2.6).