### PR TITLE
IR-1734 Sync package.json version to 21.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "money-to-prisoners-common",
   "description": "Prisoner Money - Common",
-  "version": "21.2.5",
+  "version": "21.2.6",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What
Bump `package.json` version from 21.2.5 to 21.2.6 to match `mtp_common/__init__.py`.

## Why
PR #779 bumped the Python version in `__init__.py` to 21.2.6 (released to PyPI) but did not update `package.json`, which the `bump_version` task normally keeps in sync. This is a cosmetic consistency fix — it did not affect the 21.2.6 PyPI release (that version comes from `__init__.py`).