### PR TITLE
IR-1740 Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Setup nodejs
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - name: Install os dependencies
+        run: sudo apt-get install gettext
+      - name: Install python dependencies
+        run: |
+          pip install -U setuptools pip wheel
+          pip install --editable .[testing]
+      - name: Run tests
+        run: python run.py --verbosity 2 test


### PR DESCRIPTION
## What

Adds `.github/workflows/test.yml` — runs the `mtp_common` test suite on GitHub Actions on every push, mirroring the setup in the existing `release.yml` (Python 3.12 + Node from `.nvmrc`, `gettext`, `pip install --editable .[testing]`, `python run.py --verbosity 2 test`).

Part of the CircleCI → GitHub Actions migration (IR-1740). common is a **library** — no Docker image, ECR, or deploy — so this is just the test job. Runs alongside the existing CircleCI `test` job (dual-run); PyPI publishing is already on GitHub Actions (`release.yml`).