### PR TITLE
IR-1782 Drop AWS requirement from docker-compose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,36 +151,12 @@ Each app describes its own installation in its read-me file, but here’s a quic
 
 After this has been done once, bringing up apps again only requires repeating step 5.
 
-**Running using docker-compose (requires access to the private deploy repository)**
+**Running using docker-compose**
 
-1. Get access to `money-to-prisoners-deploy`_ and see read-me inside to unlock it.
+App images are published as public packages at ``ghcr.io/ministryofjustice/money-to-prisoners-*``,
+so no credentials, AWS access or registry login are needed – docker pulls them anonymously.
 
-2. Setup local environment:
-
-   1. Get the docker registry address of ECR used for deployed environment in Cloud Platform. In the ``deploy`` repo:
-
-   .. code-block:: sh
-
-     ./manage.py config docker-login  # log docker into ECR
-     ./manage.py app ci-settings [any mtp app name]  # note the $ECR_REGISTRY value
-
-   Alternatively, this value can be derived from the ``ecr`` kubernetes secret in the production namespace in Cloud Platform.
-   Use the value of ``repo_url`` up to the first ``/``.
-
-   2. Create a ``.env`` file in this repository’s root directory adding this ``ECR_REGISTRY`` value:
-
-   .. code-block::
-
-     ECR_REGISTRY=?????????.amazonaws.com
-
-3. Pull images from private docker registry in Cloud Platform. In the ``deploy`` repo:
-
-.. code-block:: sh
-
-  ./manage.py config docker-login  # only necessary if not done above
-  ./manage.py image pull-ecr
-
-4. Launch all apps in concert. In this repo:
+1. Launch all apps in concert. In this repo:
 
 .. code-block:: sh
 
@@ -188,19 +164,19 @@ After this has been done once, bringing up apps again only requires repeating st
 
    NB: The newer ``docker compose up`` form only works after the ``docker-compose up`` has already built the containers the first time!
 
-5. Create standard users and populate database with sample data. In this repo:
+2. Create standard users and populate database with sample data. In this repo:
 
 .. code-block:: sh
 
   docker-compose exec api ./manage.py load_test_data
 
 After this has been done once, bringing up the full stack in future only requires running ``docker-compose up``
-or ``docker compose up`` in this repo. Deleting docker images, containers or volumes will require repeating steps 3 to 5.
+or ``docker compose up`` in this repo. Deleting docker images, containers or volumes will require repeating both steps.
 
 If you run into issues with the dockerised development environment, the following troubleshooting steps should reset the state:
 
 * Shutdown existing docker-compose containers, and remove volumes/networks/images with ``docker-compose down -v --rmi all`` from this repo’s root directory (note this will wipe your local database, omit the ``-v`` to prevent this)
-* Pull fresh base images (step 3 above)
+* Pull fresh app images via ``docker-compose pull`` from this repo’s root directory
 * Rebuild the app images without cache via ``docker-compose build --no-cache`` from this repo’s root directory
 * Restart the apps in the background via ``docker-compose up -d`` from this repo’s root directory
 * Tail the logs at your leisure via ``docker-compose logs <app>`` from money-to-prisoners-common root directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-environment: &default-environment
   # apps should define their own environment variables and fallbacks;
   # only docker-compose-specific overrides should go here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,6 @@ services:
     build:
       context: ../money-to-prisoners-api
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8000:8000"
       - "3000:3000"
@@ -62,8 +60,6 @@ services:
     build:
       context: ../money-to-prisoners-cashbook
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8001:8001"
       - "3001:3001"
@@ -89,8 +85,6 @@ services:
     build:
       context: ../money-to-prisoners-bank-admin
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8002:8002"
       - "3002:3002"
@@ -116,8 +110,6 @@ services:
     build:
       context: ../money-to-prisoners-noms-ops
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8003:8003"
       - "3003:3003"
@@ -143,8 +135,6 @@ services:
     build:
       context: ../money-to-prisoners-send-money
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8004:8004"
       - "3004:3004"
@@ -170,8 +160,6 @@ services:
     build:
       context: ../money-to-prisoners-start-page
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8005:8080"
     user: mtp
@@ -184,8 +172,6 @@ services:
     build:
       context: ../money-to-prisoners-emails
       dockerfile: Dockerfile-dev
-      args:
-        ECR_REGISTRY: ${ECR_REGISTRY}
     ports:
       - "8006:8006"
       - "3006:3006"


### PR DESCRIPTION
Phase 5 of IR-1782 — **the change the ticket was actually raised for.**

> "having it private makes it hard to run up the services locally in docker-compose"

## Before

Every service passed an `ECR_REGISTRY` build arg so its dev image could be based
on the private ECR image. Getting the stack up meant:

1. get access to the private `money-to-prisoners-deploy` repo and unlock it with git-crypt
2. run `./manage.py config docker-login` and `./manage.py app ci-settings` to find the registry address
3. create a `.env` file containing `ECR_REGISTRY=?????????.amazonaws.com`
4. `./manage.py image pull-ecr`
5. `docker-compose up`
6. `docker-compose exec api ./manage.py load_test_data`

…and you needed AWS credentials throughout.

## After

App images are public packages at `ghcr.io/ministryofjustice/money-to-prisoners-*`,
which docker pulls anonymously. The build arg and the `.env` file it needed are
both gone, and the read-me setup drops to:

1. `docker-compose up`
2. `docker-compose exec api ./manage.py load_test_data`

**No AWS account, no deploy repo access, no registry login.**

## Paired change

Each app repo has a one-line `Dockerfile-dev` change pointing at its GHCR
package. **Both sides need to merge** for the stack to come up:

- api#885, bank-admin#415, cashbook#638, emails#68, noms-ops#641,
  send-money#502, start-page#177

## Verified

- `docker compose config` resolves with `ECR_REGISTRY`, `AWS_*` and
  `GITHUB_TOKEN` all unset and no `.env` present — no errors, and no service
  carries build args any more
- all seven services still have their correct build contexts
- logged out of ghcr.io, the new base images resolve and pull anonymously

## Sequencing note

`money-to-prisoners-emails` is the one service whose package does not exist yet —
its first publish (emails#67) is still building. Once that lands, all seven
resolve. Everything else is ready now.

## Not included

`docker-compose.yml` still carries a `version:` key, which recent docker warns is
obsolete on every invocation. Unrelated to this change, so left alone, but it is
a one-line removal if you want the noise gone for the developers this PR is
aimed at.
