### PR TITLE
IR-1782 Fix the build badge and link to the service documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,12 @@ Money to Prisoners Common
 A Django app containing utilities and assets common to all Prisoner Money applications.
 This version is only tested with Django 5.2.
 
-.. image:: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common.svg?style=svg
-    :target: https://circleci.com/gh/ministryofjustice/money-to-prisoners-common
+.. image:: https://github.com/ministryofjustice/money-to-prisoners-common/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/ministryofjustice/money-to-prisoners-common/actions/workflows/test.yml
+
+How this library fits into the wider service — architecture, data flows, deployment and
+support — is documented in `money-to-prisoners-deploy
+<https://github.com/ministryofjustice/money-to-prisoners-deploy/blob/main/docs/README.md>`_.
 
 Features
 --------


### PR DESCRIPTION
Part of a documentation refresh ahead of two developers joining — see [deploy#548](https://github.com/ministryofjustice/money-to-prisoners-deploy/pull/548) for the service-wide docs this links to.

- **Replaces the CircleCI build badge with the GitHub Actions one.** The badge pointed at a CI system that no longer runs, so it was showing a broken image on the front page of the repo.
- **Links to the new service documentation** — architecture, data flows, deployment, secrets and support.

No other changes.
