### PR TITLE
IR-1782 Fix docker-compose failing to start the stack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Local Development Environment
 
 Prisoner Money apps can be run natively (i.e. directly by python on your machine) or using docker-compose.
 Using docker-compose is perhaps the easiest way to bring up all Prisoner Money apps in concert,
-but it requires access to the private `money-to-prisoners-deploy`_ infrastructure.
+and needs no credentials of any kind.
 However, when editing this common library, it’s easier to run them natively
 because this package can be installed in "editable" mode.
 
@@ -159,6 +159,13 @@ After this has been done once, bringing up apps again only requires repeating st
 
 App images are published as public packages at ``ghcr.io/ministryofjustice/money-to-prisoners-*``,
 so no credentials, AWS access or registry login are needed – docker pulls them anonymously.
+
+NB: docker-compose builds each app from its own checkout, so **all the app repositories above must be
+cloned side-by-side** in one directory first. It is not enough to clone this repository alone.
+
+Your own ``settings/local.py`` in any app is deliberately ignored inside the containers –
+see ``docker/no-local-settings.py`` for why. Overrides for the containers belong in
+``docker-compose.yml``.
 
 1. Launch all apps in concert. In this repo:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - "3000:3000"
     volumes:
       - ../money-to-prisoners-api:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_api/settings/local.py:ro
       - api_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
@@ -63,6 +65,8 @@ services:
       - "3001:3001"
     volumes:
       - ../money-to-prisoners-cashbook:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_cashbook/settings/local.py:ro
       - cashbook_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
@@ -88,6 +92,8 @@ services:
       - "3002:3002"
     volumes:
       - ../money-to-prisoners-bank-admin:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_bank_admin/settings/local.py:ro
       - bank-admin_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
@@ -113,6 +119,8 @@ services:
       - "3003:3003"
     volumes:
       - ../money-to-prisoners-noms-ops:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_noms_ops/settings/local.py:ro
       - noms-ops_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
@@ -138,6 +146,8 @@ services:
       - "3004:3004"
     volumes:
       - ../money-to-prisoners-send-money:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_send_money/settings/local.py:ro
       - send-money_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common
@@ -175,6 +185,8 @@ services:
       - "3006:3006"
     volumes:
       - ../money-to-prisoners-emails:/app
+      # see docker/no-local-settings.py
+      - ./docker/no-local-settings.py:/app/mtp_emails/settings/local.py:ro
       - emails_node_modules:/app/node_modules
     # Uncomment following lines and restart containers to install money-to-prisoners-common in editable mode
     #   - ../money-to-prisoners-common:/money-to-prisoners-common

--- a/docker/no-local-settings.py
+++ b/docker/no-local-settings.py
@@ -1,0 +1,13 @@
+# This file is deliberately empty.
+#
+# Each app's settings/base.py ends with `try: from .local import *`, so a developer's
+# own settings/local.py is applied last and wins. That file is meant for running the app
+# natively on the host, and local.py.sample points the database at 127.0.0.1.
+#
+# docker-compose bind-mounts each app repository into its container for live reload, which
+# brings local.py in with it. The app then ignores DB_HOST=db and tries to reach postgres
+# on 127.0.0.1 inside its own container, where nothing is listening.
+#
+# So docker-compose mounts this file over each app's settings/local.py. Local overrides for
+# the containers belong in docker-compose.yml as environment variables instead, where they
+# are visible to everyone rather than sitting in a gitignored file.


### PR DESCRIPTION
`docker-compose up` does not bring the stack up. The api container exits 100 with:

```
django.db.utils.OperationalError: connection to server at "127.0.0.1", port 5432 failed: Connection refused
```

## Cause

Each app's `settings/base.py` ends with `try: from .local import *`. docker-compose bind-mounts the app repository into its container for live reload, which brings the developer's own `settings/local.py` in with it — and `local.py.sample` hard-codes `HOST: '127.0.0.1'`. So the api ignores `DB_HOST=db` and tries to reach postgres inside its own container.

`wait-for-it db:5432` passes first, which is why the failure looks like a database problem rather than a settings one.

The native setup instructions tell you to create `local.py`, so **anyone who has set up native development cannot use docker-compose at all.** `.dockerignore` already excludes `local.py` from image builds; a bind mount is not affected by it.

## Fix

Mount an empty file over each app's `settings/local.py`. No app repository changes, so this works as soon as it merges.

## Verified

With `mtp_api/settings/local.py` present, on Apple Silicon:

| | |
|---|---|
| api, cashbook, bank-admin, noms-ops, send-money, emails | `/ping.json` → 200 |
| `load_test_data` | completes |
| Cashbook sign-in as `test-prison-1` | 302, authenticated page renders |

`start-page` was not verified — its `apk add` step could not reach `dl-cdn.alpinelinux.org` from a container in my environment, unrelated to this change.

## Also

Corrects two things in the README: docker-compose no longer needs the private deploy repository (stale — it contradicted the section below it), and it does need every app repository cloned side by side, which was not stated.